### PR TITLE
chore: gh workflow update

### DIFF
--- a/.github/workflows/check-and-add-license-header.yml
+++ b/.github/workflows/check-and-add-license-header.yml
@@ -57,7 +57,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: ${{ steps.branch-name.outputs.head_ref_branch }}
         env:
@@ -77,7 +77,7 @@ jobs:
         if: ${{ always() && github.ref_protected == true }}  # Make sure to enable branch protection even if other steps fail
         with:
           route: POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: ${{ steps.branch-name.outputs.head_ref_branch }}
         env:

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -2,7 +2,7 @@ name: create-release-branch
 on: workflow_dispatch
 jobs:
   create-release-branch:
-    if: ${{github.ref_name == 'stage'}} 
+    if: ${{github.ref_name == 'stage'}}
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -15,7 +15,7 @@ jobs:
           uuid=`uuidgen`
           echo 'Creating release branch'
           git checkout -b release/$uuid
-          
+
           echo 'Rush version to bump updates'
           node common/scripts/install-run-rush.js version --bump -b release/$uuid --ignore-git-hooks
 

--- a/.github/workflows/create-release-pr-to-main.yml
+++ b/.github/workflows/create-release-pr-to-main.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   create-release-branch-pr-to-main:
-    if: contains(github.ref_name, 'gh-workflow')
+    if: contains(github.ref_name, 'release/')
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -20,10 +20,9 @@ jobs:
     - name: create-pull-request
       uses: repo-sync/pull-request@v2
       with:
-        destination_branch: "testDevelop"
+        destination_branch: "main"
         pr_title: ${{ inputs.title }}
         pr_template: ".github/PULL_REQUEST_TEMPLATE.md"
         pr_label: "auto-release-pr"
         pr_allow_empty: false
         github_token: ${{ secrets.MERGE_TOKEN }}
-

--- a/.github/workflows/create-release-pr-to-main.yml
+++ b/.github/workflows/create-release-pr-to-main.yml
@@ -1,4 +1,9 @@
-name: create release branch pr to main
+#
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+name: Create-release-branch-pr-to-main
 
 on:
   workflow_dispatch:
@@ -9,7 +14,7 @@ on:
 
 jobs:
   create-release-branch-pr-to-main:
-    if: contains(github.ref_name, 'release/')
+    if: startsWith(github.ref_name, 'release/')
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/create-release-pr-to-main.yml
+++ b/.github/workflows/create-release-pr-to-main.yml
@@ -1,0 +1,29 @@
+name: create release branch pr to main
+
+on:
+  workflow_dispatch:
+    inputs:
+      title:
+        description: PR Title
+        required: true
+
+jobs:
+  create-release-branch-pr-to-main:
+    if: contains(github.ref_name, 'gh-workflow')
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.MERGE_TOKEN }}
+        fetch-depth: 0
+
+    - name: create-pull-request
+      uses: repo-sync/pull-request@v2
+      with:
+        destination_branch: "testDevelop"
+        pr_title: ${{ inputs.title }}
+        pr_template: ".github/PULL_REQUEST_TEMPLATE.md"
+        pr_label: "auto-release-pr"
+        pr_allow_empty: false
+        github_token: ${{ secrets.MERGE_TOKEN }}
+

--- a/.github/workflows/enable-feat-protection.yml
+++ b/.github/workflows/enable-feat-protection.yml
@@ -44,7 +44,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: PUT /repos/{owner}/{repo}/branches/{branch}/protection
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: ${{ github.ref_name }}
           enforce_admins: true

--- a/.github/workflows/enable-feat-protection.yml
+++ b/.github/workflows/enable-feat-protection.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   enable-feat-branch-protection:
-    if: contains(github.ref_name, 'feat/')
+    if: startsWith(github.ref_name, 'feat/')
     runs-on: ubuntu-latest
     steps:
       - name: 'Construct required_pull_request_reviews object'

--- a/.github/workflows/feat-deletion.yml
+++ b/.github/workflows/feat-deletion.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   delete-feat-branch-on-merge:
-    if: github.event.pull_request.merged == true && contains(github.head_ref, 'feat/')
+    if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'feat/')
     runs-on: ubuntu-latest
     steps:
       - name: Delete feat/* branch protection after merge to develop

--- a/.github/workflows/feat-deletion.yml
+++ b/.github/workflows/feat-deletion.yml
@@ -19,7 +19,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: DELETE /repos/{owner}/{repo}/branches/{branch}/protection
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: ${{ github.head_ref }}
         env:

--- a/.github/workflows/merge-develop-to-stage.yml
+++ b/.github/workflows/merge-develop-to-stage.yml
@@ -86,6 +86,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
+      - name: enable merge commits
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/{owner}/{repo}
+          owner: awslabs
+          repo: solution-spark-on-aws
+          allow_merge_commit: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+
       - name: Merge to stage
         run: |
           echo "Set the COMMIT_ID to merge to stage, to current workflow commit id, if no readme commit was made"
@@ -104,6 +114,16 @@ jobs:
           echo
           git merge $COMMIT_ID --ff-only --no-edit
           git push origin stage
+
+      - name: disable merge commits
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/{owner}/{repo}
+          owner: awslabs
+          repo: solution-spark-on-aws
+          allow_merge_commit: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
           
       - name: Enable branch protection on stage
         uses: octokit/request-action@v2.x

--- a/.github/workflows/merge-develop-to-stage.yml
+++ b/.github/workflows/merge-develop-to-stage.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - 'develop'
-  
+
 jobs:
   readme-commit:
     uses: awslabs/solution-spark-on-aws/.github/workflows/readme-commit.yml@develop
@@ -65,7 +65,7 @@ jobs:
     name: Merge develop to stage
     runs-on: ubuntu-20.04
     needs: [readme-commit, deploy-swb-reference]
-    env: 
+    env:
       COMMIT_HASH: "${{ needs.readme-commit.outputs.commit_hash }}"
       CHANGES_DETECTED: "${{ needs.readme-commit.outputs.changes_detected }}"
     steps:
@@ -124,7 +124,7 @@ jobs:
           allow_merge_commit: false
         env:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
-          
+
       - name: Enable branch protection on stage
         uses: octokit/request-action@v2.x
         if: always() # Make sure to enable branch protection even if other steps fail

--- a/.github/workflows/merge-develop-to-stage.yml
+++ b/.github/workflows/merge-develop-to-stage.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   readme-commit:
-    uses: awslabs/solution-spark-on-aws/.github/workflows/readme-commit.yml@develop
+    uses: aws-solutions/solution-spark-on-aws/.github/workflows/readme-commit.yml@develop
     secrets:
       gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
       passphrase: ${{ secrets.PASSPHRASE }}
@@ -34,7 +34,7 @@ jobs:
 
   deploy-swb-reference:
     needs: [pre-deployment-check]
-    uses: awslabs/solution-spark-on-aws/.github/workflows/deploy-integration-swb-reference.yml@develop
+    uses: aws-solutions/solution-spark-on-aws/.github/workflows/deploy-integration-swb-reference.yml@develop
     secrets:
       aws-dev-region: ${{ secrets.AWS_DEV_REGION }}
       role-to-assume: ${{ secrets.ASSUME_ROLE }}
@@ -45,14 +45,14 @@ jobs:
 
   deploy-swb-demo:
     needs: [ deploy-swb-reference]
-    uses: awslabs/solution-spark-on-aws/.github/workflows/deploy-swb-reference-demo.yml@develop
+    uses: aws-solutions/solution-spark-on-aws/.github/workflows/deploy-swb-reference-demo.yml@develop
     secrets:
       role-to-assume: ${{ secrets.ASSUME_ROLE }}
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK }}
 
   # deploy-example:
   #   needs: [pre-deployment-check]
-  #   uses: awslabs/solution-spark-on-aws/.github/workflows/deploy-integration-example.yml@develop
+  #   uses: aws-solutions/solution-spark-on-aws/.github/workflows/deploy-integration-example.yml@develop
   #   secrets:
   #     aws-dev-region: ${{ secrets.AWS_DEV_REGION }}
   #     role-to-assume: ${{ secrets.ASSUME_ROLE }}
@@ -80,7 +80,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: stage
         env:
@@ -90,7 +90,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           allow_merge_commit: true
         env:
@@ -119,7 +119,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           allow_merge_commit: false
         env:
@@ -130,7 +130,7 @@ jobs:
         if: always() # Make sure to enable branch protection even if other steps fail
         with:
           route: POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: stage
         env:

--- a/.github/workflows/merge-release-pr-to-main.yml
+++ b/.github/workflows/merge-release-pr-to-main.yml
@@ -1,4 +1,9 @@
-name: merge-release-pr-to-main
+#
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+name: Merge-release-pr-to-main
 
 on:
   workflow_dispatch:
@@ -9,6 +14,7 @@ on:
 
 jobs:
   merge-release-pr-to-main:
+    if: startsWith(github.ref_name, 'release/')
     runs-on: ubuntu-20.04
     steps:
       - name: enable merge commits

--- a/.github/workflows/merge-release-pr-to-main.yml
+++ b/.github/workflows/merge-release-pr-to-main.yml
@@ -14,10 +14,28 @@ on:
 
 jobs:
   merge-release-pr-to-main:
-    if: startsWith(github.ref_name, 'release/')
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions-cool/check-user-permission@v2
+        id: check_admin
+        with:
+          require: 'admin'
+          username: ${{ github.triggering_actor }}
+
+      - name: check if PR source is a release branch
+        if: steps.check_admin.outputs.require-result
+        id: check_source
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/{owner}/{repo}/pulls/{pull_number}
+          owner: insignias
+          repo: React
+          pull_number: ${{ inputs.pr_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+
       - name: enable merge commits
+        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/')
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
@@ -28,6 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: merge release branch pr to main
+        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/')
         uses: octokit/request-action@v2.x
         with:
           route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
@@ -39,6 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: disable merge commits
+        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/')
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}

--- a/.github/workflows/merge-release-pr-to-main.yml
+++ b/.github/workflows/merge-release-pr-to-main.yml
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: enable merge commits
-        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/')
+        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/') && startsWith(fromJson(steps.check_source.outputs.data).base.ref, 'main')
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: merge release branch pr to main
-        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/')
+        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/') && startsWith(fromJson(steps.check_source.outputs.data).base.ref, 'main')
         uses: octokit/request-action@v2.x
         with:
           route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
@@ -58,7 +58,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: disable merge commits
-        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/')
+        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/') && startsWith(fromJson(steps.check_source.outputs.data).base.ref, 'main')
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}

--- a/.github/workflows/merge-release-pr-to-main.yml
+++ b/.github/workflows/merge-release-pr-to-main.yml
@@ -1,0 +1,43 @@
+name: merge-release-pr-to-main
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to merge
+        required: true
+
+jobs:
+  merge-release-pr-to-main:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: enable merge commits
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/{owner}/{repo}
+          owner: awslabs
+          repo: solution-spark-on-aws
+          allow_merge_commit: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+
+      - name: merge release branch pr to main
+        uses: octokit/request-action@v2.x
+        with:
+          route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
+          owner: awslabs
+          repo: solution-spark-on-aws
+          pull_number: ${{ inputs.pr_number }}
+          merge_method: 'merge'
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+
+      - name: disable merge commits
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/{owner}/{repo}
+          owner: awslabs
+          repo: solution-spark-on-aws
+          allow_merge_commit: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}

--- a/.github/workflows/merge-release-pr-to-main.yml
+++ b/.github/workflows/merge-release-pr-to-main.yml
@@ -28,8 +28,8 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: GET /repos/{owner}/{repo}/pulls/{pull_number}
-          owner: insignias
-          repo: React
+          owner: aws-solutions
+          repo: solution-spark-on-aws
           pull_number: ${{ inputs.pr_number }}
         env:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           allow_merge_commit: true
         env:
@@ -50,7 +50,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           pull_number: ${{ inputs.pr_number }}
           merge_method: 'merge'
@@ -62,7 +62,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           allow_merge_commit: false
         env:

--- a/.github/workflows/merge-release-pr-to-main.yml
+++ b/.github/workflows/merge-release-pr-to-main.yml
@@ -22,20 +22,12 @@ jobs:
           require: 'admin'
           username: ${{ github.triggering_actor }}
 
-      - name: check if PR source is a release branch
-        if: steps.check_admin.outputs.require-result
-        id: check_source
-        uses: octokit/request-action@v2.x
-        with:
-          route: GET /repos/{owner}/{repo}/pulls/{pull_number}
-          owner: aws-solutions
-          repo: solution-spark-on-aws
-          pull_number: ${{ inputs.pr_number }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
 
       - name: enable merge commits
-        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/') && startsWith(fromJson(steps.check_source.outputs.data).base.ref, 'main')
+        if: steps.check_admin.outputs.require-result && startsWith(steps.branch_name.outputs.head_ref_branch, 'release/') && steps.branch_name.outputs.base_ref_branch == 'main'
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
@@ -46,7 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: merge release branch pr to main
-        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/') && startsWith(fromJson(steps.check_source.outputs.data).base.ref, 'main')
+        if: steps.check_admin.outputs.require-result && startsWith(steps.branch_name.outputs.head_ref_branch, 'release/') && steps.branch_name.outputs.base_ref_branch == 'main'
         uses: octokit/request-action@v2.x
         with:
           route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
@@ -58,7 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: disable merge commits
-        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.check_source.outputs.data).head.ref, 'release/') && startsWith(fromJson(steps.check_source.outputs.data).base.ref, 'main')
+        if: steps.check_admin.outputs.require-result && startsWith(steps.branch_name.outputs.head_ref_branch, 'release/') && steps.branch_name.outputs.base_ref_branch == 'main'
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}

--- a/.github/workflows/publish-and-merge-to-develop.yml
+++ b/.github/workflows/publish-and-merge-to-develop.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
 
-jobs:  
+jobs:
   rush-publish:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-20.04
@@ -37,13 +37,14 @@ jobs:
           git config user.email ${{ secrets.BOT-USER-EMAIL }}
           git config user.name ${{ secrets.BOT-USER }}
           git config commit.gpgsign true
-          
+
       - name: Rush Publish
         run: |
           PUBLISH_CMD="--add-commit-details --apply --npm-auth-token ${{ secrets.NPM_AUTH_TOKEN }} --ignore-git-hooks --include-all --set-access-level public --target-branch main --publish"
           node common/scripts/install-run-rush.js publish $PUBLISH_CMD
         env:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+          
   merge-to-develop:
     runs-on: ubuntu-20.04
     needs: [rush-publish]
@@ -63,7 +64,7 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-      
+
       # There's no way for github actions to push to a protected branch. This is a workaround
       # See https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/30
       - name: Temporarily disable branch protection on develop
@@ -75,12 +76,22 @@ jobs:
           branch: develop
         env:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
-      
+
       - name: Set git config
         run: |
           git config user.email ${{ secrets.BOT-USER-EMAIL }}
           git config user.name ${{ secrets.BOT-USER }}
           git config commit.gpgsign true
+
+      - name: enable merge commits
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/{owner}/{repo}
+          owner: awslabs
+          repo: solution-spark-on-aws
+          allow_merge_commit: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: Merge to develop
         run: |
@@ -93,7 +104,17 @@ jobs:
           echo
           git merge $COMMIT_ID --ff --no-edit -m "Merge main to develop"
           git push origin develop
-      
+
+      - name: disable merge commits
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/{owner}/{repo}
+          owner: awslabs
+          repo: solution-spark-on-aws
+          allow_merge_commit: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+
       - name: Enable branch protection on develop
         uses: octokit/request-action@v2.x
         if: always() # Make sure to enable branch protection even if other steps fail

--- a/.github/workflows/publish-and-merge-to-develop.yml
+++ b/.github/workflows/publish-and-merge-to-develop.yml
@@ -71,7 +71,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: develop
         env:
@@ -87,7 +87,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           allow_merge_commit: true
         env:
@@ -109,7 +109,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           allow_merge_commit: false
         env:
@@ -120,7 +120,7 @@ jobs:
         if: always() # Make sure to enable branch protection even if other steps fail
         with:
           route: POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: develop
         env:

--- a/.github/workflows/readme-commit.yml
+++ b/.github/workflows/readme-commit.yml
@@ -75,7 +75,7 @@ jobs:
         uses: octokit/request-action@v2.x
         with:
           route: DELETE /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: develop
         env:
@@ -97,7 +97,7 @@ jobs:
         if: always() # Make sure to enable branch protection even if other steps fail
         with:
           route: POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins
-          owner: awslabs
+          owner: aws-solutions
           repo: solution-spark-on-aws
           branch: develop
         env:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
1. `create-release-pr-to-main.yml`:
       1. Manually trigger this workflow to create a PR from `release/*` branch to `main` branch
       2. Should be triggered from `release/*` branch
3. `merge-develop-to-stage.yml`: Updates to enable merge commit and disable merge commit after the merge is done
4. `merge-release-pr-to-main.yml`:  Maunally trigger this workflow to merge the `release/*` branch PR to `main`. 
      1. Input: PR number of the PR created by `create-release-pr-to-main.yml` as input. 
      2. This workflow performs following steps:
	    1. enables merge commits
	    2. Performs merge commit to `main` branch
	    3. disables merge commit
      3. Only `admins` allowed to merge
      4. Added a check to make sure this workflow is being used to merge PRs with source branch starting with 'release/' and base branch == 'main' only
5. `publish-and-merge-to-develop.yml`: Updates to enable merge commit and disable merge commit after the merge is done
6. Update the github repo owner to `aws-solutions`

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.