### PR TITLE
feat: mock dataset service response and e2e create internal dataset flow

### DIFF
--- a/common/changes/@aws/swb-app/sevu-features-GALI-1876-integrate-new-params-2_2022-10-18-14-13.json
+++ b/common/changes/@aws/swb-app/sevu-features-GALI-1876-integrate-new-params-2_2022-10-18-14-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "mock dataset service response",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/common/changes/@aws/workbench-core-datasets-ui/sevu-features-GALI-1876-integrate-new-params-2_2022-10-18-14-13.json
+++ b/common/changes/@aws/workbench-core-datasets-ui/sevu-features-GALI-1876-integrate-new-params-2_2022-10-18-14-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-datasets-ui",
+      "comment": "ui updates to send correct parameters to be",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-datasets-ui"
+}

--- a/common/changes/@aws/workbench-core-datasets/sevu-features-GALI-1876-integrate-new-params-2_2022-10-18-14-13.json
+++ b/common/changes/@aws/workbench-core-datasets/sevu-features-GALI-1876-integrate-new-params-2_2022-10-18-14-13.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-datasets",
+      "comment": "create dataset schema updates",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-datasets"
+}

--- a/solutions/swb-app/src/datasetRoutes.ts
+++ b/solutions/swb-app/src/datasetRoutes.ts
@@ -21,7 +21,8 @@ export function setUpDSRoutes(
   dataSetService: DataSetService,
   dataSetStoragePlugin: DataSetsStoragePlugin,
   datasetStorageAccount: string,
-  mainAccountId: string
+  mainAccountId: string,
+  region: string
 ): void {
   // creates new prefix in S3 (assumes S3 bucket exist already)
   router.post(
@@ -33,11 +34,17 @@ export function setUpDSRoutes(
         datasetStorageAccount,
         req.body.path,
         mainAccountId,
-        req.body.region,
+        region,
         dataSetStoragePlugin
       );
 
-      res.status(201).send(dataSet);
+      const responseDataset = {
+        ...dataSet,
+        description: req.body.description,
+        customMetadata: req.body.customMetadata
+      };
+
+      res.status(201).send(responseDataset);
     })
   );
 
@@ -51,7 +58,7 @@ export function setUpDSRoutes(
         datasetStorageAccount,
         req.body.path,
         mainAccountId,
-        req.body.region,
+        region,
         dataSetStoragePlugin
       );
       res.status(201).send(dataSet);

--- a/solutions/swb-app/src/generateRouter.ts
+++ b/solutions/swb-app/src/generateRouter.ts
@@ -107,7 +107,8 @@ export function generateRouter(apiRouteConfig: ApiRouteConfig): Express {
     apiRouteConfig.dataSetService,
     apiRouteConfig.dataSetsStoragePlugin,
     process.env.S3_DATASET_BUCKET_NAME!,
-    process.env.MAIN_ACCOUNT_ID!
+    process.env.MAIN_ACCOUNT_ID!,
+    process.env.AWS_REGION!
   );
   setUpAccountRoutes(router, apiRouteConfig.account);
   setUpAuthRoutes(router, authenticationService, logger);

--- a/solutions/swb-reference/integration-tests/support/clientSession.ts
+++ b/solutions/swb-reference/integration-tests/support/clientSession.ts
@@ -52,8 +52,11 @@ export default class ClientSession {
       },
       function (error: AxiosError) {
         if (error.response) {
+          console.error(error.response.data);
           return Promise.reject(new HttpError(error.response.status, error.response.data));
         }
+
+        console.error(error);
         return Promise.reject(error);
       }
     );

--- a/solutions/swb-reference/integration-tests/support/resources/datasets/datasets.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/datasets/datasets.ts
@@ -28,17 +28,17 @@ export default class Datasets extends CollectionResource {
     return {
       datasetName: resource.datasetName ?? dataSetName,
       path: resource.path ?? dataSetName,
-      storageName: resource.storageName,
-      awsAccountId: resource.awsAccountId,
-      region: resource.region
+      description: resource.description,
+      customMetadata: resource.customMetadata
     };
   }
 }
 
 interface DataSetCreateRequest {
   datasetName: string;
-  storageName: string;
   path: string;
-  awsAccountId: string;
-  region: string;
+  description?: string;
+  customMetadata: {
+    owningProjectId: string;
+  };
 }

--- a/solutions/swb-reference/integration-tests/support/utils/utilities.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/utilities.ts
@@ -8,6 +8,14 @@ import { DEFAULT_POLLING_INTERVAL_SECONDS, DEFAULT_POLLING_MAX_WAITING_SECONDS }
 import HttpError from './HttpError';
 
 /**
+ * Marks all properties (including nested) as Partial.
+ * https://stackoverflow.com/questions/47914536/use-partial-in-nested-property-with-typescript
+ */
+type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>;
+};
+
+/**
  * Returns a promise that will be resolved in the requested time, ms.
  * Example: await sleep(200);
  * https://stackoverflow.com/questions/951021/what-is-the-javascript-version-of-sleep/39914235#39914235
@@ -59,4 +67,4 @@ async function poll<T>(
   }
 }
 
-export { sleep, checkHttpError, poll, getFakeEnvId };
+export { sleep, checkHttpError, poll, getFakeEnvId, RecursivePartial };

--- a/solutions/swb-reference/integration-tests/tests/isolated/datasets/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/datasets/create.test.ts
@@ -6,7 +6,7 @@ import ClientSession from '../../../support/clientSession';
 import Setup from '../../../support/setup';
 import HttpError from '../../../support/utils/HttpError';
 import RandomTextGenerator from '../../../support/utils/randomTextGenerator';
-import { checkHttpError } from '../../../support/utils/utilities';
+import { checkHttpError, RecursivePartial } from '../../../support/utils/utilities';
 
 describe('datasets create negative tests', () => {
   const setup: Setup = new Setup();
@@ -28,13 +28,15 @@ describe('datasets create negative tests', () => {
   const validLaunchParameters = {
     datasetName: randomTextGenerator.getFakeText('fakeName'),
     path: randomTextGenerator.getFakeText('fakePath'),
-    region: randomTextGenerator.getFakeText('fakeRegion')
+    customMetadata: {
+      owningProjectId: randomTextGenerator.getFakeText('fakeOwningProjectId')
+    }
   };
 
   describe('missing parameters', () => {
     test('datasetName', async () => {
       try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
+        const invalidParam: Partial<typeof validLaunchParameters> = { ...validLaunchParameters };
         delete invalidParam.datasetName;
         await adminSession.resources.datasets.create(invalidParam, false);
       } catch (e) {
@@ -51,7 +53,7 @@ describe('datasets create negative tests', () => {
 
     test('path', async () => {
       try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
+        const invalidParam: Partial<typeof validLaunchParameters> = { ...validLaunchParameters };
         delete invalidParam.path;
         await adminSession.resources.datasets.create(invalidParam, false);
       } catch (e) {
@@ -66,21 +68,41 @@ describe('datasets create negative tests', () => {
       }
     });
 
-    test('region', async () => {
-      try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
-        delete invalidParam.region;
-        await adminSession.resources.datasets.create(invalidParam, false);
-      } catch (e) {
-        checkHttpError(
-          e,
-          new HttpError(400, {
-            statusCode: 400,
-            error: 'Bad Request',
-            message: "requires property 'region'"
-          })
-        );
-      }
+    describe('customMetadata', () => {
+      test('customMetadata', async () => {
+        try {
+          const invalidParam: Partial<typeof validLaunchParameters> = { ...validLaunchParameters };
+          delete invalidParam.customMetadata;
+          await adminSession.resources.datasets.create(invalidParam, false);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              statusCode: 400,
+              error: 'Bad Request',
+              message: "requires property 'customMetadata'"
+            })
+          );
+        }
+      });
+
+      test('customMetadata.owningProjectId', async () => {
+        try {
+          const invalidParam: RecursivePartial<typeof validLaunchParameters> = { ...validLaunchParameters };
+          delete invalidParam.customMetadata?.owningProjectId;
+
+          await adminSession.resources.datasets.create(invalidParam, false);
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              statusCode: 400,
+              error: 'Bad Request',
+              message: "customMetadata requires property 'owningProjectId'"
+            })
+          );
+        }
+      });
     });
 
     test('all parameters', async () => {
@@ -92,7 +114,8 @@ describe('datasets create negative tests', () => {
           new HttpError(400, {
             statusCode: 400,
             error: 'Bad Request',
-            message: "requires property 'datasetName'. requires property 'path'. requires property 'region'"
+            message:
+              "requires property 'datasetName'. requires property 'path'. requires property 'customMetadata'"
           })
         );
       }

--- a/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
@@ -29,7 +29,10 @@ describe('multiStep dataset integration test', () => {
     const dataSetBody = {
       path: datasetName, // using same name to help potential troubleshooting
       datasetName,
-      region: settings.get('awsRegion')
+      description: datasetName,
+      customMetadata: {
+        owningProjectId: datasetName
+      }
     };
 
     const { data: dataSet } = await adminSession.resources.datasets.create(dataSetBody);

--- a/workbench-core/datasets-ui/src/api/datasets.ts
+++ b/workbench-core/datasets-ui/src/api/datasets.ts
@@ -16,7 +16,7 @@ const useDatasets = (): { datasets: DatasetItem[]; areDatasetsLoading: boolean }
 };
 
 const createDataset = async (dataset: CreateDatasetForm): Promise<void> => {
-  await httpApiPost('datasets', { ...dataset });
+  await httpApiPost('datasets', { ...dataset, path: dataset.datasetName });
 };
 
 export { useDatasets, createDataset };

--- a/workbench-core/datasets-ui/src/components/CreateInternalDatasetForm.tsx
+++ b/workbench-core/datasets-ui/src/components/CreateInternalDatasetForm.tsx
@@ -54,7 +54,7 @@ export const NewDatasetForm = ({
       'nameError',
       setFormErrors,
       datasetNameValidationRules,
-      formData.name
+      formData.datasetName
     );
 
     isValid =
@@ -70,7 +70,7 @@ export const NewDatasetForm = ({
         'projectIdError',
         setFormErrors,
         datasetProjectIdValidationRules,
-        formData.metadata?.owningProjectId
+        formData.customMetadata?.owningProjectId
       ) && isValid;
 
     return isValid;
@@ -119,9 +119,9 @@ export const NewDatasetForm = ({
           >
             <Input
               data-testid="datasetName"
-              value={formData?.name || ''}
+              value={formData?.datasetName || ''}
               onChange={({ detail: { value } }) => {
-                setFormData({ ...formData, name: value });
+                setFormData({ ...formData, datasetName: value });
                 validateField<string | undefined, CreateDatasetFormValidation>(
                   'nameError',
                   setFormErrors,
@@ -169,13 +169,13 @@ export const NewDatasetForm = ({
                   ? null
                   : projects
                       .map((p) => ({ label: p.name, value: p.id }))
-                      .filter((p) => p.value === formData?.metadata?.owningProjectId)[0] || null
+                      .filter((p) => p.value === formData?.customMetadata?.owningProjectId)[0] || null
               }
               loadingText="Loading Projects"
               options={projects.map((p) => ({ label: p.name, value: p.id }))}
-              selectedAriaLabel={formData?.metadata?.owningProjectId}
+              selectedAriaLabel={formData?.customMetadata?.owningProjectId}
               onChange={({ detail: { selectedOption } }) => {
-                setFormData({ ...formData, metadata: { owningProjectId: selectedOption.value } });
+                setFormData({ ...formData, customMetadata: { owningProjectId: selectedOption.value } });
                 validateField<string | undefined, CreateDatasetFormValidation>(
                   'projectIdError',
                   setFormErrors,

--- a/workbench-core/datasets-ui/src/models/Dataset.ts
+++ b/workbench-core/datasets-ui/src/models/Dataset.ts
@@ -17,9 +17,9 @@ interface DatasetMetadata {
 }
 
 export interface CreateDatasetForm {
-  name?: string;
+  datasetName?: string;
   description?: string;
-  metadata?: DatasetMetadata;
+  customMetadata?: DatasetMetadata;
 }
 
 export interface CreateDatasetFormValidation {

--- a/workbench-core/datasets-ui/src/pages/new.tsx
+++ b/workbench-core/datasets-ui/src/pages/new.tsx
@@ -37,7 +37,7 @@ export const NewDatasetPage: NextPage = () => {
     await router.push({
       pathname: '/datasets',
       query: {
-        message: `Internal dataset [${formData.name}] has been created successfully. You can now upload files to the dataset.`,
+        message: `Internal dataset [${formData.datasetName}] has been created successfully. You can now upload files to the dataset.`,
         notificationType: 'success'
       }
     });

--- a/workbench-core/datasets/src/schemas/createDataSet.ts
+++ b/workbench-core/datasets/src/schemas/createDataSet.ts
@@ -12,10 +12,18 @@ const CreateDataSetSchema: Schema = {
   properties: {
     datasetName: { type: 'string' },
     path: { type: 'string' },
-    region: { type: 'string' }
+    description: { type: 'string' },
+    customMetadata: {
+      type: 'object',
+      properties: {
+        owningProjectId: { type: 'string' }
+      },
+      additionalProperties: false,
+      required: ['owningProjectId']
+    }
   },
   additionalProperties: false,
-  required: ['datasetName', 'path', 'region']
+  required: ['datasetName', 'path', 'customMetadata']
 };
 
 export default CreateDataSetSchema;


### PR DESCRIPTION
Issue #, if available: GALI-1876

Description of changes:

  e2e create internal dataset flow. Pass ui payload to backend; mock temporary unavailable dataset service response - echo back ui params; negative dataset tests


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.