### PR TITLE
fix: viperlight scans

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -5,3 +5,14 @@ solutions/swb-reference/NOTICE
 solutions/swb-ui/NOTICE
 workbench-core/accounts/NOTICE
 workbench-core/authentication/NOTICE
+workbench-core/environments/NOTICE
+workbench-core/environments-ui/NOTICE
+workbench-core/example/infrastructure/NOTICE
+workbench-core/repo-scripts/repo-toolbox/NOTICE
+workbench-core/swb-common-ui/NOTICE
+solutions/swb-reference/src/environment/sagemakerNotebook/sagemakerNotebookEnvironmentConnectionService.test.ts:26
+workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:168
+workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:228
+workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:271
+solutions/example-ui-app/src/models/User.ts:19
+solutions/swb-ui/end-to-end-tests/cypress/fixtures/example.json:3

--- a/.viperlightignore
+++ b/.viperlightignore
@@ -1,18 +1,27 @@
 # This file is used by Viperlight utility to override findings (false alarm)
+
+#NOTICE files
+workbench-core/datasets/NOTICE
 workbench-core/datasets-ui/NOTICE
 solutions/swb-app/NOTICE
 solutions/swb-reference/NOTICE
 solutions/swb-ui/NOTICE
 workbench-core/accounts/NOTICE
+workbench-core/accounts-ui/NOTICE
 workbench-core/authentication/NOTICE
 workbench-core/environments/NOTICE
 workbench-core/environments-ui/NOTICE
 workbench-core/example/infrastructure/NOTICE
 workbench-core/repo-scripts/repo-toolbox/NOTICE
 workbench-core/swb-common-ui/NOTICE
+workbench-core/infrastructure/NOTICE
+
+# Test files
 solutions/swb-reference/src/environment/sagemakerNotebook/sagemakerNotebookEnvironmentConnectionService.test.ts:26
 workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:168
 workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:228
 workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:271
+workbench-core/authentication/src/plugins/cognitoUserManagementPlugin.test.ts:46
+
 solutions/example-ui-app/src/models/User.ts:19
 solutions/swb-ui/end-to-end-tests/cypress/fixtures/example.json:3

--- a/.viperlightignore
+++ b/.viperlightignore
@@ -1,0 +1,8 @@
+# This file is used by Viperlight utility to override findings (false alarm)
+'**/NOTICE'
+#workbench-core/datasets-ui/NOTICE
+#solutions/swb-app/NOTICE
+#solutions/swb-reference/NOTICE
+#solutions/swb-ui/NOTICE
+#workbench-core/accounts/NOTICE
+#workbench-core/authentication/NOTICE

--- a/.viperlightignore
+++ b/.viperlightignore
@@ -1,8 +1,7 @@
 # This file is used by Viperlight utility to override findings (false alarm)
-'**/NOTICE'
-#workbench-core/datasets-ui/NOTICE
-#solutions/swb-app/NOTICE
-#solutions/swb-reference/NOTICE
-#solutions/swb-ui/NOTICE
-#workbench-core/accounts/NOTICE
-#workbench-core/authentication/NOTICE
+workbench-core/datasets-ui/NOTICE
+solutions/swb-app/NOTICE
+solutions/swb-reference/NOTICE
+solutions/swb-ui/NOTICE
+workbench-core/accounts/NOTICE
+workbench-core/authentication/NOTICE

--- a/.viperlightignore
+++ b/.viperlightignore
@@ -17,11 +17,11 @@ workbench-core/swb-common-ui/NOTICE
 workbench-core/infrastructure/NOTICE
 
 # Test files
-solutions/swb-reference/src/environment/sagemakerNotebook/sagemakerNotebookEnvironmentConnectionService.test.ts:26
-workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:168
-workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:228
-workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:271
-workbench-core/authentication/src/plugins/cognitoUserManagementPlugin.test.ts:46
+solutions/swb-reference/src/environment/sagemakerNotebook/sagemakerNotebookEnvironmentConnectionService.test.ts:26   # SecretAccessKey: 'sampleSecretAccessKey' is not real secret
+workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:168 # SecretAccessKey: 'sampleSecretAccessKey' is not real secret
+workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:228 # SecretAccessKey: 'sampleSecretAccessKey' is not real secret
+workbench-core/environments/src/utilities/environmentLifecycleHelper.test.ts:271 # SecretAccessKey: 'sampleSecretAccessKey' is not real secret
+workbench-core/authentication/src/plugins/cognitoUserManagementPlugin.test.ts:46 # email: 'john@doe.com' is not real email
 
-solutions/example-ui-app/src/models/User.ts:19
-solutions/swb-ui/end-to-end-tests/cypress/fixtures/example.json:3
+solutions/example-ui-app/src/models/User.ts:19 # email: 'sample.user@amazon.com' is not real email
+solutions/swb-ui/end-to-end-tests/cypress/fixtures/example.json:3 # "email": "hello@cypress.io" is not real email

--- a/common/changes/@aws/workbench-core-base/fix-viperlight-scans_2022-10-18-18-17.json
+++ b/common/changes/@aws/workbench-core-base/fix-viperlight-scans_2022-10-18-18-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "update generateCognitoToken to allow param rootUserNameParamStorePath",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/solutions/swb-reference/integration-tests/config/example.yaml
+++ b/solutions/swb-reference/integration-tests/config/example.yaml
@@ -12,7 +12,7 @@
 #terminatedEnvId: ''   # id of an environment that has already been terminated
 
 ## Cognito Integ Test Client
-#rootUsername: ''
+#rootUserNameParamStorePath: ''
 #rootPasswordParamStorePath: ''
 
 ## Pre-requisite for running aws-accounts integration test

--- a/solutions/swb-reference/integration-tests/config/testEnv.yaml
+++ b/solutions/swb-reference/integration-tests/config/testEnv.yaml
@@ -12,5 +12,5 @@ envType: 'sagemakerNotebook'
 terminatedEnvId: 'env-b44262fb-ed34-47ae-a4a4-d2d9d9c7a5d5' # id of an environment that has already been terminated
 
 #Cognito Integ Test Client
-rootUsername: 'aws-chamonix-dev+testenvroot@amazon.com'
+rootUserNameParamStorePath: '/swb/testEnv/rootUser/email'
 rootPasswordParamStorePath: '/swb/testEnv/rootUser/password'

--- a/solutions/swb-reference/integration-tests/support/setup.ts
+++ b/solutions/swb-reference/integration-tests/support/setup.ts
@@ -37,17 +37,17 @@ export default class Setup {
     if (this._defaultAdminSession === undefined) {
       const userPoolId = this._settings.get('cognitoUserPoolId');
       const clientId = this._settings.get('cognitoUserPoolClientId');
-      const rootUsername = this._settings.get('rootUsername');
+      const rootUserNameParamStorePath = this._settings.get('rootUserNameParamStorePath');
       const rootPasswordParamStorePath = this._settings.get('rootPasswordParamStorePath');
       const awsRegion = this._settings.get('awsRegion');
 
       const cognitoTokenService = new CognitoTokenService(awsRegion);
-      const { accessToken } = await cognitoTokenService.generateCognitoToken(
+      const { accessToken } = await cognitoTokenService.generateCognitoToken({
         userPoolId,
         clientId,
-        rootUsername,
+        rootUserNameParamStorePath,
         rootPasswordParamStorePath
-      );
+      });
 
       const session = this._getClientSession(accessToken);
       this._sessions.push(session);

--- a/solutions/swb-reference/integration-tests/support/utils/settings.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/settings.ts
@@ -13,7 +13,7 @@ interface Setting {
   envType: string;
   runId: string;
   terminatedEnvId: string;
-  rootUsername: string;
+  rootUserNameParamStorePath: string;
   rootPasswordParamStorePath: string;
 
   // Main CFN template outputs

--- a/solutions/swb-reference/scripts/generateCognitoTokens.js
+++ b/solutions/swb-reference/scripts/generateCognitoTokens.js
@@ -30,8 +30,8 @@ try {
 const clientId = outputs.cognitoUserPoolClientId;
 const userPoolId = outputs.cognitoUserPoolId;
 const region = outputs.awsRegion;
-const username = process.argv[2];
-const password = process.argv[3];
+const rootUserName = process.argv[2];
+const rootPassword = process.argv[3];
 
 const csrf = new Csrf();
 const secret = csrf.secretSync();
@@ -40,13 +40,12 @@ const token = csrf.create(secret);
 async function run() {
   try {
     const cognitoTokenService = new CognitoTokenService(region);
-    const tokens = await cognitoTokenService.generateCognitoToken(
+    const tokens = await cognitoTokenService.generateCognitoToken({
       userPoolId,
       clientId,
-      username,
-      undefined,
-      password
-    );
+      rootUserName,
+      rootPassword
+    });
     console.log({
       ...tokens,
       csrfCookie: secret,

--- a/solutions/swb-reference/src/config/demo.yaml
+++ b/solutions/swb-reference/src/config/demo.yaml
@@ -2,6 +2,6 @@
 stage: demo
 awsRegion: us-east-2
 awsRegionShortName: oh
-rootUserEmail: aws-chamonix-dev+demoRoot@amazon.com
+rootUserEmailParamStorePath: '/swb/demo/rootUser/email'
 allowedOrigins: ['http://localhost:3000']
 cognitoDomain: 'chamonix-dev-demo-domain'

--- a/solutions/swb-reference/src/config/example.yaml
+++ b/solutions/swb-reference/src/config/example.yaml
@@ -1,7 +1,7 @@
 #stage: dev # Stage Name
 #awsRegion: us-east-1
 #awsRegionShortName: va #two or three letter abbreviation for the region. You can choose your own abbreviation
-#rootUserEmail: user@example.com    # SWB will automatically create this Cognito user for you.
+#rootUserEmailParamStorePath: '/swb/<stage>/rootUser/email'  # Log into your AWS account and store root user email in SSM Param store
 #allowedOrigins: ["http://localhost:3000"] # SWB API will allow this domains to make requests.
 #cognitoDomain: 'user-test' # Must be globally unique
 

--- a/solutions/swb-reference/src/config/testEnv.yaml
+++ b/solutions/swb-reference/src/config/testEnv.yaml
@@ -2,6 +2,6 @@
 stage: testEnv
 awsRegion: us-east-1
 awsRegionShortName: va
-rootUserEmail: aws-chamonix-dev+testEnvRoot@amazon.com
+rootUserEmailParamStorePath: '/swb/testEnv/rootUser/email'
 allowedOrigins: ['http://localhost:3000', 'http://localhost:3002']
 cognitoDomain: 'chamonix-dev-test-domain'

--- a/solutions/swb-reference/src/constants.ts
+++ b/solutions/swb-reference/src/constants.ts
@@ -5,9 +5,10 @@
 
 import fs from 'fs';
 import { join } from 'path';
+import { AwsService } from '@aws/workbench-core-base';
 import yaml from 'js-yaml';
 
-function getConstants(): {
+interface Constants {
   STAGE: string;
   STACK_NAME: string;
   SC_PORTFOLIO_NAME: string;
@@ -21,7 +22,6 @@ function getConstants(): {
   S3_ARTIFACT_BUCKET_BOOTSTRAP_PREFIX: string;
   LAUNCH_CONSTRAINT_ROLE_OUTPUT_KEY: string;
   AMI_IDS_TO_SHARE: string;
-  ROOT_USER_EMAIL: string;
   USER_POOL_CLIENT_NAME: string;
   USER_POOL_NAME: string;
   STATUS_HANDLER_ARN_OUTPUT_KEY: string;
@@ -34,14 +34,15 @@ function getConstants(): {
   CLIENT_ID: string;
   CLIENT_SECRET: string;
   MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY: string;
-} {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const config: any = yaml.load(
-    // __dirname is a variable that reference the current directory. We use it so we can dynamically navigate to the
-    // correct file
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    fs.readFileSync(join(__dirname, `../../src/config/${process.env.STAGE}.yaml`), 'utf8') // nosemgrep
-  );
+}
+
+interface SecretConstants {
+  ROOT_USER_EMAIL: string;
+}
+
+//CDK Constructs doesn't support Promises https://github.com/aws/aws-cdk/issues/8273
+function getConstants(): Constants {
+  const config = getConfig();
 
   const STACK_NAME = `swb-${config.stage}-${config.awsRegionShortName}`;
   const SC_PORTFOLIO_NAME = `swb-${config.stage}-${config.awsRegionShortName}`; // Service Catalog Portfolio Name
@@ -50,7 +51,6 @@ function getConstants(): {
   const S3_ACCESS_BUCKET_PREFIX = 'service-workbench-access-log';
   const S3_ARTIFACT_BUCKET_SC_PREFIX = 'service-catalog-cfn-templates/';
   const S3_ARTIFACT_BUCKET_BOOTSTRAP_PREFIX = 'environment-files/'; // Location of env bootstrap scripts in the artifacts bucket
-  const ROOT_USER_EMAIL = config.rootUserEmail;
   const allowedOrigins: string[] = config.allowedOrigins || [];
   const uiClientURL = getUiClientUrl();
   if (uiClientURL) allowedOrigins.push(uiClientURL);
@@ -87,7 +87,6 @@ function getConstants(): {
     S3_ARTIFACT_BUCKET_BOOTSTRAP_PREFIX,
     LAUNCH_CONSTRAINT_ROLE_OUTPUT_KEY,
     AMI_IDS_TO_SHARE: JSON.stringify(AMI_IDS),
-    ROOT_USER_EMAIL,
     USER_POOL_CLIENT_NAME,
     USER_POOL_NAME,
     ALLOWED_ORIGINS: JSON.stringify(allowedOrigins),
@@ -101,6 +100,34 @@ function getConstants(): {
     CLIENT_SECRET,
     MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY
   };
+}
+
+async function getConstantsWithSecrets(): Promise<Constants & SecretConstants> {
+  const config = getConfig();
+  const AWS_REGION = config.awsRegion;
+  const awsService = new AwsService({ region: AWS_REGION });
+  const rootUserParamStorePath = config.rootUserEmailParamStorePath;
+
+  const ROOT_USER_EMAIL = await getSSMParamValue(awsService, rootUserParamStorePath);
+  return { ...getConstants(), ROOT_USER_EMAIL };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getConfig(): any {
+  return yaml.load(
+    // __dirname is a variable that reference the current directory. We use it so we can dynamically navigate to the
+    // correct file
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    fs.readFileSync(join(__dirname, `../../src/config/${process.env.STAGE}.yaml`), 'utf8') // nosemgrep
+  );
+}
+async function getSSMParamValue(awsService: AwsService, ssmParamName: string): Promise<string> {
+  const response = await awsService.clients.ssm.getParameter({
+    Name: ssmParamName,
+    WithDecryption: true
+  });
+
+  return response.Parameter!.Value!;
 }
 
 function getUiClientUrl(): string {
@@ -124,4 +151,4 @@ function getUiClientUrl(): string {
   }
 }
 
-export { getConstants };
+export { getConstants, getConstantsWithSecrets };

--- a/solutions/swb-reference/src/constants.ts
+++ b/solutions/swb-reference/src/constants.ts
@@ -58,9 +58,9 @@ function getConstants(): Constants {
   const USER_POOL_NAME = `swb-userpool-${config.stage}-${config.awsRegionShortName}`;
   const COGNITO_DOMAIN = config.cognitoDomain;
   const WEBSITE_URLS = allowedOrigins;
-  const USER_POOL_ID = config.userPoolId;
-  const CLIENT_ID = config.clientId;
-  const CLIENT_SECRET = config.clientSecret;
+  const USER_POOL_ID = config.userPoolId || '';
+  const CLIENT_ID = config.clientId || '';
+  const CLIENT_SECRET = config.clientSecret || '';
 
   const AMI_IDS: string[] = [];
 
@@ -112,15 +112,27 @@ async function getConstantsWithSecrets(): Promise<Constants & SecretConstants> {
   return { ...getConstants(), ROOT_USER_EMAIL };
 }
 
+interface Config {
+  stage: string;
+  awsRegion: string;
+  awsRegionShortName: string;
+  rootUserEmailParamStorePath: string;
+  allowedOrigins: string[];
+  cognitoDomain: string;
+  userPoolId?: string;
+  clientId?: string;
+  clientSecret?: string;
+}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getConfig(): any {
+function getConfig(): Config {
   return yaml.load(
     // __dirname is a variable that reference the current directory. We use it so we can dynamically navigate to the
     // correct file
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     fs.readFileSync(join(__dirname, `../../src/config/${process.env.STAGE}.yaml`), 'utf8') // nosemgrep
-  );
+  ) as unknown as Config;
 }
+
 async function getSSMParamValue(awsService: AwsService, ssmParamName: string): Promise<string> {
   const response = await awsService.clients.ssm.getParameter({
     Name: ssmParamName,

--- a/solutions/swb-reference/src/postDeployment.ts
+++ b/solutions/swb-reference/src/postDeployment.ts
@@ -11,7 +11,7 @@ import { promisify } from 'util';
 import { AwsService } from '@aws/workbench-core-base';
 import { CognitoSetup, ServiceCatalogSetup } from '@aws/workbench-core-environments';
 import Axios from 'axios';
-import { getConstants } from './constants';
+import { getConstants, getConstantsWithSecrets } from './constants';
 
 async function run(): Promise<void> {
   const {
@@ -23,7 +23,7 @@ async function run(): Promise<void> {
     STACK_NAME,
     ROOT_USER_EMAIL,
     USER_POOL_NAME
-  } = getConstants();
+  } = await getConstantsWithSecrets();
   const scSetup = new ServiceCatalogSetup({
     AWS_REGION,
     S3_ARTIFACT_BUCKET_SC_PREFIX,


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Remove email from config files. Username is now pulled from SSM param store, instead of hard coding it in the config file. This is the same as what we are currently doing with password.
* Disable viperlight warnings for false positive cases

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.