### PR TITLE
fix(swb-reference): updated postDeployment file path parsing

### DIFF
--- a/common/changes/@aws/workbench-core-environments/patch-post-deployment-script-update_2022-10-20-22-12.json
+++ b/common/changes/@aws/workbench-core-environments/patch-post-deployment-script-update_2022-10-20-22-12.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-environments",
+      "comment": "Updated file path parsing to use the `path` module.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-environments"
+}

--- a/workbench-core/environments/src/postDeployment/serviceCatalogSetup.ts
+++ b/workbench-core/environments/src/postDeployment/serviceCatalogSetup.ts
@@ -8,7 +8,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 
-import { join } from 'path';
+import { join, basename } from 'path';
 import { Readable } from 'stream';
 import { _Object } from '@aws-sdk/client-s3';
 import { InvalidParametersException, ProductViewDetail } from '@aws-sdk/client-service-catalog';
@@ -157,7 +157,7 @@ export default class ServiceCatalogSetup {
 
   private async _uploadTemplateToS3(s3Bucket: string, prefix: string, filePaths: string[]): Promise<void> {
     for (const filePath of filePaths) {
-      const fileName = filePath.split('/').pop();
+      const fileName = basename(filePath);
       // nosemgrep
       const fileContent = fs.readFileSync(filePath);
       const putObjectParam = {
@@ -212,7 +212,7 @@ export default class ServiceCatalogSetup {
     }
     const envsToFilePath: { [key: string]: string } = {};
     cfnFilePaths.forEach((filePath: string) => {
-      const fileName = filePath.split('/').pop();
+      const fileName = basename(filePath);
       if (fileName) {
         const localCfnTemplateMd5Sum = md5File.sync(cfnFilePaths[0]);
         // eslint-disable-next-line security/detect-object-injection


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Updated `serviceCatalogSetup` to use the `path` module to parse file path rather than parsing manually per [this StackOverflow post](https://stackoverflow.com/questions/423376/how-to-get-the-file-name-from-a-full-path-using-javascript) 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.