### PR TITLE
fix: consistent error response from ALB vs APIGW

### DIFF
--- a/solutions/swb-reference/integration-tests/support/clientSession.ts
+++ b/solutions/swb-reference/integration-tests/support/clientSession.ts
@@ -40,6 +40,8 @@ export default class ClientSession {
     }
 
     this._axiosInstance = axios.create({
+      // TODO: Replace line below with `http://${this._settings.get(MainAccountLoadBalancerDnsNameOutput)} to send requests to ALB
+      // Can only use "https://" for ALB DNS name once port 443 has been established with TLS
       baseURL: this._settings.get('apiUrlOutput'),
       timeout: 30000, // 30 seconds to mimic API gateway timeout
       headers

--- a/solutions/swb-reference/integration-tests/support/clientSession.ts
+++ b/solutions/swb-reference/integration-tests/support/clientSession.ts
@@ -40,7 +40,7 @@ export default class ClientSession {
     }
 
     this._axiosInstance = axios.create({
-      // TODO: Replace line below with `http://${this._settings.get(MainAccountLoadBalancerDnsNameOutput)} to send requests to ALB
+      // TODO: Replace line below with `http://${this._settings.get(mainAccountLoadBalancerDnsNameOutput)} to send requests to ALB
       // Can only use "https://" for ALB DNS name once port 443 has been established with TLS
       baseURL: this._settings.get('apiUrlOutput'),
       timeout: 30000, // 30 seconds to mimic API gateway timeout

--- a/solutions/swb-reference/integration-tests/support/clientSession.ts
+++ b/solutions/swb-reference/integration-tests/support/clientSession.ts
@@ -40,7 +40,7 @@ export default class ClientSession {
     }
 
     this._axiosInstance = axios.create({
-      // TODO: Replace line below with `http://${this._settings.get(mainAccountLoadBalancerDnsNameOutput)} to send requests to ALB
+      // TODO: Replace line below with `http://${this._settings.get('MainAccountLoadBalancerDnsNameOutput')} to send requests to ALB
       // Can only use "https://" for ALB DNS name once port 443 has been established with TLS
       baseURL: this._settings.get('apiUrlOutput'),
       timeout: 30000, // 30 seconds to mimic API gateway timeout

--- a/solutions/swb-reference/integration-tests/support/utils/HttpError.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/HttpError.ts
@@ -8,12 +8,16 @@ export default class HttpError extends Error {
   public statusCode: number;
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
   public body: any;
+  public statusDescription: string;
+  public isBase64Encoded?: boolean;
+  public headers?: { 'Content-Type': string };
 
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public constructor(statusCode: number, body: any) {
+  public constructor(statusCode: number, body: any, description?: string) {
     super(`HttpError with statusCode ${statusCode}`);
     this.statusCode = statusCode;
     this.body = body;
+    this.statusDescription = description || '';
   }
 
   public isEqual(error: Error): boolean {

--- a/solutions/swb-reference/integration-tests/support/utils/HttpError.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/HttpError.ts
@@ -6,14 +6,12 @@ import _ from 'lodash';
 
 export default class HttpError extends Error {
   public statusCode: number;
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public body: any;
+  public body: unknown;
   public statusDescription: string;
   public isBase64Encoded?: boolean;
   public headers?: { 'Content-Type': string };
 
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  public constructor(statusCode: number, body: any, description?: string) {
+  public constructor(statusCode: number, body: unknown, description?: string) {
     super(`HttpError with statusCode ${statusCode}`);
     this.statusCode = statusCode;
     this.body = body;

--- a/solutions/swb-reference/integration-tests/support/utils/settings.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/settings.ts
@@ -23,6 +23,8 @@ interface Setting {
   awsRegion: string;
   DataSetsBucketName: string;
   apiUrlOutput: string;
+  MainAccountLoadBalancerArnOutput: string;
+  MainAccountLoadBalancerDnsNameOutput: string;
   S3BucketArtifactsArnOutput: string;
   uiClientURL: string;
   LaunchConstraintIamRoleNameOutput: string;

--- a/solutions/swb-reference/integration-tests/support/utils/settings.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/settings.ts
@@ -23,8 +23,8 @@ interface Setting {
   awsRegion: string;
   DataSetsBucketName: string;
   apiUrlOutput: string;
-  MainAccountLoadBalancerArnOutput: string;
-  MainAccountLoadBalancerDnsNameOutput: string;
+  mainAccountLoadBalancerArnOutput: string;
+  mainAccountLoadBalancerDnsNameOutput: string;
   S3BucketArtifactsArnOutput: string;
   uiClientURL: string;
   LaunchConstraintIamRoleNameOutput: string;

--- a/solutions/swb-reference/integration-tests/support/utils/settings.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/settings.ts
@@ -23,8 +23,8 @@ interface Setting {
   awsRegion: string;
   DataSetsBucketName: string;
   apiUrlOutput: string;
-  mainAccountLoadBalancerArnOutput: string;
-  mainAccountLoadBalancerDnsNameOutput: string;
+  MainAccountLoadBalancerArnOutput: string;
+  MainAccountLoadBalancerDnsNameOutput: string;
   S3BucketArtifactsArnOutput: string;
   uiClientURL: string;
   LaunchConstraintIamRoleNameOutput: string;

--- a/solutions/swb-reference/src/SWBStack.ts
+++ b/solutions/swb-reference/src/SWBStack.ts
@@ -59,7 +59,7 @@ export class SWBStack extends Stack {
     CLIENT_SECRET: string;
     USER_POOL_ID: string;
     MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY: string;
-    MAIN_ACCT_ALB_OUTPUT_KEY: string;
+    MAIN_ACCT_ALB_ARN_OUTPUT_KEY: string;
   };
 
   private _accessLogsBucket: Bucket;
@@ -90,7 +90,7 @@ export class SWBStack extends Stack {
       CLIENT_ID,
       CLIENT_SECRET,
       MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY,
-      MAIN_ACCT_ALB_OUTPUT_KEY,
+      MAIN_ACCT_ALB_ARN_OUTPUT_KEY,
       VPC_ID,
       SUBNET_IDS
     } = getConstants();
@@ -142,7 +142,7 @@ export class SWBStack extends Stack {
       CLIENT_SECRET: clientSecret,
       USER_POOL_ID: userPoolId,
       MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY,
-      MAIN_ACCT_ALB_OUTPUT_KEY
+      MAIN_ACCT_ALB_ARN_OUTPUT_KEY
     };
 
     this._createInitialOutputs(AWS_REGION, AWS_REGION_SHORT_NAME, UI_CLIENT_URL);
@@ -199,7 +199,7 @@ export class SWBStack extends Stack {
       targets: [new LambdaTarget(proxyLambda)]
     });
 
-    new CfnOutput(this, this.lambdaEnvVars.MAIN_ACCT_ALB_OUTPUT_KEY, {
+    new CfnOutput(this, this.lambdaEnvVars.MAIN_ACCT_ALB_ARN_OUTPUT_KEY, {
       value: alb.applicationLoadBalancer.loadBalancerArn
     });
   }

--- a/solutions/swb-reference/src/constants.ts
+++ b/solutions/swb-reference/src/constants.ts
@@ -78,8 +78,8 @@ function getConstants(): {
   const LAUNCH_CONSTRAINT_ROLE_OUTPUT_KEY = 'LaunchConstraintIamRoleNameOutput';
   const STATUS_HANDLER_ARN_OUTPUT_KEY = 'StatusHandlerLambdaArnOutput';
   const MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY = 'MainAccountEncryptionKeyOutput';
-  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'MainAccountLoadBalancerArnOutput';
-  const MAIN_ACCT_ALB_DNS_OUTPUT_KEY = 'MainAccountLoadBalancerDnsNameOutput';
+  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'mainAccountLoadBalancerArnOutput';
+  const MAIN_ACCT_ALB_DNS_OUTPUT_KEY = 'mainAccountLoadBalancerDnsNameOutput';
 
   return {
     STAGE: config.stage,

--- a/solutions/swb-reference/src/constants.ts
+++ b/solutions/swb-reference/src/constants.ts
@@ -78,8 +78,8 @@ function getConstants(): {
   const LAUNCH_CONSTRAINT_ROLE_OUTPUT_KEY = 'LaunchConstraintIamRoleNameOutput';
   const STATUS_HANDLER_ARN_OUTPUT_KEY = 'StatusHandlerLambdaArnOutput';
   const MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY = 'MainAccountEncryptionKeyOutput';
-  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'mainAccountLoadBalancerArnOutput';
-  const MAIN_ACCT_ALB_DNS_OUTPUT_KEY = 'mainAccountLoadBalancerDnsNameOutput';
+  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'MainAccountLoadBalancerArnOutput';
+  const MAIN_ACCT_ALB_DNS_OUTPUT_KEY = 'MainAccountLoadBalancerDnsNameOutput';
 
   return {
     STAGE: config.stage,

--- a/solutions/swb-reference/src/constants.ts
+++ b/solutions/swb-reference/src/constants.ts
@@ -34,7 +34,8 @@ function getConstants(): {
   CLIENT_ID: string;
   CLIENT_SECRET: string;
   MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY: string;
-  MAIN_ACCT_ALB_OUTPUT_KEY: string;
+  MAIN_ACCT_ALB_ARN_OUTPUT_KEY: string;
+  MAIN_ACCT_ALB_DNS_OUTPUT_KEY: string;
   VPC_ID: string;
   SUBNET_IDS: string[];
 } {
@@ -77,7 +78,8 @@ function getConstants(): {
   const LAUNCH_CONSTRAINT_ROLE_OUTPUT_KEY = 'LaunchConstraintIamRoleNameOutput';
   const STATUS_HANDLER_ARN_OUTPUT_KEY = 'StatusHandlerLambdaArnOutput';
   const MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY = 'MainAccountEncryptionKeyOutput';
-  const MAIN_ACCT_ALB_OUTPUT_KEY = 'MainAccountLoadBalancerArnKeyOutput';
+  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'MainAccountLoadBalancerArnOutput';
+  const MAIN_ACCT_ALB_DNS_OUTPUT_KEY = 'MainAccountLoadBalancerDnsNameOutput';
 
   return {
     STAGE: config.stage,
@@ -106,7 +108,8 @@ function getConstants(): {
     CLIENT_ID,
     CLIENT_SECRET,
     MAIN_ACCT_ENCRYPTION_KEY_ARN_OUTPUT_KEY,
-    MAIN_ACCT_ALB_OUTPUT_KEY,
+    MAIN_ACCT_ALB_ARN_OUTPUT_KEY,
+    MAIN_ACCT_ALB_DNS_OUTPUT_KEY,
     VPC_ID,
     SUBNET_IDS
   };

--- a/solutions/swb-reference/src/proxyHandlerLambda.ts
+++ b/solutions/swb-reference/src/proxyHandlerLambda.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import HttpError from '../integration-tests/support/utils/HttpError';
 
 /* eslint-disable-next-line */
@@ -78,6 +78,11 @@ export async function handler(event: any) {
       response.body = JSON.stringify(data);
     }
   } catch (err) {
+    if (!(err instanceof AxiosError) || !err.response) {
+      console.error(`Unsupported error encountered: ${JSON.stringify(err)}`);
+      throw err;
+    }
+
     const error = new HttpError(
       err.response!.status,
       JSON.stringify({
@@ -91,9 +96,9 @@ export async function handler(event: any) {
     error.isBase64Encoded = false;
     error.headers = { 'Content-Type': 'application/json' };
 
-    console.log(`Error seen: ${JSON.stringify(error)}`);
+    console.error(`Application error encountered: ${JSON.stringify(error)}`);
 
-    // The error object has to be returned like this to ensure integration tests are backwards compatible
+    // The error object has to be returned like this for integration tests' backwards compatibility
     return error;
   }
 

--- a/solutions/swb-ui/infrastructure/src/SWBUIStack.ts
+++ b/solutions/swb-ui/infrastructure/src/SWBUIStack.ts
@@ -31,7 +31,7 @@ export class SWBUIStack extends Stack {
     API_BASE_URL: string;
     AWS_REGION: string;
     S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY: string;
-    MAIN_ACCT_ALB_OUTPUT_KEY: string;
+    MAIN_ACCT_ALB_ARN_OUTPUT_KEY: string;
     S3_ARTIFACT_BUCKET_NAME: string;
     S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME: string;
     ACCESS_IDENTITY_ARTIFACT_NAME: string;
@@ -52,7 +52,7 @@ export class SWBUIStack extends Stack {
       API_BASE_URL,
       AWS_REGION,
       S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY,
-      MAIN_ACCT_ALB_OUTPUT_KEY,
+      MAIN_ACCT_ALB_ARN_OUTPUT_KEY,
       S3_ARTIFACT_BUCKET_NAME,
       S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME,
       ACCESS_IDENTITY_ARTIFACT_NAME,
@@ -77,7 +77,7 @@ export class SWBUIStack extends Stack {
       API_BASE_URL,
       AWS_REGION,
       S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY,
-      MAIN_ACCT_ALB_OUTPUT_KEY,
+      MAIN_ACCT_ALB_ARN_OUTPUT_KEY,
       S3_ARTIFACT_BUCKET_NAME,
       S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME,
       ACCESS_IDENTITY_ARTIFACT_NAME,
@@ -94,7 +94,7 @@ export class SWBUIStack extends Stack {
     const distribution = this._createDistribution(bucket);
     this._deployS3BucketAndInvalidateDistribution(bucket, distribution);
     this._addCognitoURLOutput();
-    createECSCluster(this, API_BASE_URL, MAIN_ACCT_ALB_OUTPUT_KEY);
+    createECSCluster(this, API_BASE_URL, MAIN_ACCT_ALB_ARN_OUTPUT_KEY);
   }
 
   private _addS3TLSSigV4BucketPolicy(s3Bucket: Bucket): void {

--- a/solutions/swb-ui/infrastructure/src/constants.ts
+++ b/solutions/swb-ui/infrastructure/src/constants.ts
@@ -50,7 +50,7 @@ function getConstants(): {
   const S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY = 'S3BucketArtifactsArnOutput';
   // The output name below must match the value in swb-reference
   const S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY = 'S3BucketAccessLogsNameOutput';
-  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'MainAccountLoadBalancerArnOutput';
+  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'mainAccountLoadBalancerArnOutput';
 
   return {
     STAGE,

--- a/solutions/swb-ui/infrastructure/src/constants.ts
+++ b/solutions/swb-ui/infrastructure/src/constants.ts
@@ -13,7 +13,7 @@ function getConstants(): {
   STACK_NAME: string;
   S3_ACCESS_LOGS_BUCKET_PREFIX: string;
   S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY: string;
-  MAIN_ACCT_ALB_OUTPUT_KEY: string;
+  MAIN_ACCT_ALB_ARN_OUTPUT_KEY: string;
   S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY: string;
   S3_ARTIFACT_BUCKET_NAME: string;
   S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME: string;
@@ -50,7 +50,7 @@ function getConstants(): {
   const S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY = 'S3BucketArtifactsArnOutput';
   // The output name below must match the value in swb-reference
   const S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY = 'S3BucketAccessLogsNameOutput';
-  const MAIN_ACCT_ALB_OUTPUT_KEY = 'MainAccountLoadBalancerArnKeyOutput';
+  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'MainAccountLoadBalancerArnOutput';
 
   return {
     STAGE,
@@ -59,7 +59,7 @@ function getConstants(): {
     STACK_NAME,
     S3_ACCESS_LOGS_BUCKET_PREFIX,
     S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY,
-    MAIN_ACCT_ALB_OUTPUT_KEY,
+    MAIN_ACCT_ALB_ARN_OUTPUT_KEY,
     S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY,
     S3_ARTIFACT_BUCKET_NAME,
     S3_ARTIFACT_BUCKET_DEPLOYMENT_NAME,

--- a/solutions/swb-ui/infrastructure/src/constants.ts
+++ b/solutions/swb-ui/infrastructure/src/constants.ts
@@ -50,7 +50,7 @@ function getConstants(): {
   const S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY = 'S3BucketArtifactsArnOutput';
   // The output name below must match the value in swb-reference
   const S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY = 'S3BucketAccessLogsNameOutput';
-  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'mainAccountLoadBalancerArnOutput';
+  const MAIN_ACCT_ALB_ARN_OUTPUT_KEY = 'MainAccountLoadBalancerArnOutput';
 
   return {
     STAGE,


### PR DESCRIPTION
Issue #, if available:
GALI-1547

Description of changes:
- ALB must return an HTTP Error response instead of throwing one to avoid generic Bad Gateway response.
- Changes made to make integration tests backwards compatible with the use of `http:<ALB DNS Name>` base URL.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.