### PR TITLE
fix(projects): DELETE project API uses MetadataService

### DIFF
--- a/solutions/swb-app/src/generateRouter.ts
+++ b/solutions/swb-app/src/generateRouter.ts
@@ -104,7 +104,12 @@ export function generateRouter(apiRouteConfig: ApiRouteConfig): Express {
   setUpUserRoutes(router, apiRouteConfig.userManagementService);
   setUpEnvTypeRoutes(router, apiRouteConfig.environmentTypeService);
   setUpEnvTypeConfigRoutes(router, apiRouteConfig.environmentTypeConfigService);
-  setUpProjectRoutes(router, apiRouteConfig.projectService, apiRouteConfig.environmentService);
+  setUpProjectRoutes(
+    router,
+    apiRouteConfig.projectService,
+    apiRouteConfig.environmentService,
+    apiRouteConfig.metadataService
+  );
 
   // Error handling. Order of the error handlers is important
   router.use(boomErrorHandler);

--- a/solutions/swb-app/src/projectRoutes.ts
+++ b/solutions/swb-app/src/projectRoutes.ts
@@ -102,13 +102,13 @@ export function setUpProjectRoutes(
           { pageSize: 1 }
         );
 
-        const [envBoolean, { data: datasets }, { data: envTypeConfigs }] = await Promise.all([
+        const [hasEnvironments, { data: datasets }, { data: envTypeConfigs }] = await Promise.all([
           projectHasEnvironments,
           datasetDependency,
           envTypeConfigDepedency
         ]);
 
-        if (envBoolean) {
+        if (hasEnvironments) {
           throw Boom.conflict(
             `Project ${projectId} cannot be deleted because it has environments(s) associated with it`
           );

--- a/solutions/swb-app/src/projectRoutes.ts
+++ b/solutions/swb-app/src/projectRoutes.ts
@@ -12,7 +12,7 @@ import {
   DeleteProjectRequest,
   DeleteProjectRequestParser
 } from '@aws/workbench-core-accounts';
-import { validateAndParse } from '@aws/workbench-core-base';
+import { validateAndParse, MetadataService, resourceTypeToKey } from '@aws/workbench-core-base';
 import { EnvironmentService } from '@aws/workbench-core-environments';
 import Boom from '@hapi/boom';
 import { Request, Response, Router } from 'express';
@@ -20,12 +20,19 @@ import { validate } from 'jsonschema';
 import { wrapAsync } from './errorHandlers';
 import CreateProjectSchema from './schemas/projects/createProjectSchema';
 import GetProjectSchema from './schemas/projects/getProjectSchema';
+import {
+  ProjectDatasetMetadata,
+  ProjectDatasetMetadataParser,
+  ProjectEnvTypeConfigMetadata,
+  ProjectEnvTypeConfigMetadataParser
+} from './schemas/projects/projectMetadataParser';
 import { processValidatorResult } from './validatorHelper';
 
 export function setUpProjectRoutes(
   router: Router,
   projectService: ProjectService,
-  environmentService: EnvironmentService
+  environmentService: EnvironmentService,
+  metadataService: MetadataService
 ): void {
   // Get project
   router.get(
@@ -76,26 +83,44 @@ export function setUpProjectRoutes(
       async function checkDependencies(projectId: string): Promise<void> {
         // environments
         const projectHasEnvironments = environmentService.doesDependencyHaveEnvironments(projectId);
+
         // datasets
-        const projectHasDatasets = projectService.checkDependency('dataset', projectId);
+        const datasetDependency = metadataService.listDependentMetadata<ProjectDatasetMetadata>(
+          resourceTypeToKey.project,
+          projectId,
+          resourceTypeToKey.dataset,
+          ProjectDatasetMetadataParser,
+          { pageSize: 1 }
+        );
+
         // etcs
-        const projectHasEnvTypeConfigs = projectService.checkDependency('envTypeConfig', projectId);
-        const [envBoolean, datasetBoolean, envTypeConfigBoolean] = await Promise.all([
+        const envTypeConfigDepedency = metadataService.listDependentMetadata<ProjectEnvTypeConfigMetadata>(
+          resourceTypeToKey.project,
+          projectId,
+          resourceTypeToKey.envTypeConfig,
+          ProjectEnvTypeConfigMetadataParser,
+          { pageSize: 1 }
+        );
+
+        const [envBoolean, { data: datasets }, { data: envTypeConfigs }] = await Promise.all([
           projectHasEnvironments,
-          projectHasDatasets,
-          projectHasEnvTypeConfigs
+          datasetDependency,
+          envTypeConfigDepedency
         ]);
+
         if (envBoolean) {
           throw Boom.conflict(
             `Project ${projectId} cannot be deleted because it has environments(s) associated with it`
           );
         }
-        if (datasetBoolean) {
+
+        if (datasets.length) {
           throw Boom.conflict(
             `Project ${projectId} cannot be deleted because it has dataset(s) associated with it`
           );
         }
-        if (envTypeConfigBoolean) {
+
+        if (envTypeConfigs.length) {
           throw Boom.conflict(
             `Project ${projectId} cannot be deleted because it has environment type config(s) associated with it`
           );

--- a/solutions/swb-app/src/schemas/projects/projectMetadataParser.ts
+++ b/solutions/swb-app/src/schemas/projects/projectMetadataParser.ts
@@ -1,0 +1,36 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod';
+
+// Should match the schema for PROJ with DATASET
+// eslint-disable-next-line @rushstack/typedef-var
+export const ProjectDatasetMetadataParser = z
+  .object({
+    id: z.string(),
+    pk: z.string(),
+    sk: z.string(),
+    name: z.string(),
+    permission: z.array(z.string()),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+  .strict();
+
+export type ProjectDatasetMetadata = z.infer<typeof ProjectDatasetMetadataParser>;
+
+// Should match the schema for PROJ with ETC
+// eslint-disable-next-line @rushstack/typedef-var
+export const ProjectEnvTypeConfigMetadataParser = z
+  .object({
+    id: z.string(),
+    pk: z.string(),
+    sk: z.string(),
+    createdAt: z.string(),
+    updatedAt: z.string()
+  })
+  .strict();
+
+export type ProjectEnvTypeConfigMetadata = z.infer<typeof ProjectEnvTypeConfigMetadataParser>;

--- a/workbench-core/accounts/src/services/projectService.test.ts
+++ b/workbench-core/accounts/src/services/projectService.test.ts
@@ -19,7 +19,6 @@ import {
 } from '@aws-sdk/client-dynamodb';
 import { marshall } from '@aws-sdk/util-dynamodb';
 import { AuthenticatedUser } from '@aws/workbench-core-authorization';
-import DynamoDBService from '@aws/workbench-core-base/lib/aws/helpers/dynamoDB/dynamoDBService';
 import Getter from '@aws/workbench-core-base/lib/aws/helpers/dynamoDB/getter';
 import Updater from '@aws/workbench-core-base/lib/aws/helpers/dynamoDB/updater';
 import Boom from '@hapi/boom';
@@ -1632,45 +1631,6 @@ describe('ProjectService', () => {
             });
           });
         });
-      });
-    });
-  });
-
-  describe('checkDependency', () => {
-    const projectId = 'proj-123';
-
-    describe('when dependency exists', () => {
-      beforeEach(() => {
-        const queryMockResponse = { data: ['someEnvironment'] };
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .spyOn(DynamoDBService.prototype as any, 'getPaginatedItems')
-          .mockImplementationOnce(() => queryMockResponse);
-      });
-
-      test('evaluates to true', async () => {
-        // OPERATE
-        const result = await projService.checkDependency('environment', projectId);
-
-        // CHECK
-        expect(result).toEqual(true);
-      });
-    });
-
-    describe('when dependency does not exist', () => {
-      beforeEach(() => {
-        const queryMockResponse = { data: [] };
-        jest
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .spyOn(DynamoDBService.prototype as any, 'getPaginatedItems')
-          .mockImplementationOnce(() => queryMockResponse);
-      });
-      test('evaluates to false', async () => {
-        // OPERATE
-        const result = await projService.checkDependency('environment', projectId);
-
-        // CHECK
-        expect(result).toEqual(false);
       });
     });
   });

--- a/workbench-core/accounts/src/services/projectService.ts
+++ b/workbench-core/accounts/src/services/projectService.ts
@@ -20,8 +20,7 @@ import {
   fromPaginationToken,
   validateSingleSortAndFilter,
   getFilterQueryParams,
-  getSortQueryParams,
-  buildDynamoDbKey
+  getSortQueryParams
 } from '@aws/workbench-core-base';
 
 import Boom from '@hapi/boom';
@@ -307,30 +306,6 @@ export default class ProjectService {
       console.error(`Failed to delete project ${request.projectId}}`, e);
       throw Boom.internal('Could not delete Project');
     }
-  }
-
-  /**
-   * Checks if project has a dependency in the PROJ#projId collection.
-   * Specifically, checks for items that match pk = PROJ#projId and sk.beginsWith(resourceType)
-   *
-   * @param resourceType - the string that should be a resource that is a key in {@link resourceTypeToKey} object
-   * @param projectId - the project id to check for dependencies
-   * @returns true if there are dependencies on the project that match the resource type, false otherwise
-   */
-  public async checkDependency(
-    resourceType: keyof typeof resourceTypeToKey,
-    projectId: string
-  ): Promise<boolean> {
-    const queryParams: QueryParams = {
-      key: { name: 'pk', value: buildDynamoDbKey(projectId, resourceTypeToKey.project) },
-      sortKey: 'sk',
-      begins: { S: resourceTypeToKey[resourceType] },
-      limit: 1
-    };
-
-    const response = await this._aws.helpers.ddb.getPaginatedItems(queryParams);
-
-    return response.data.length > 0;
   }
 
   /**


### PR DESCRIPTION
Issue #, if available: GALI-1738 fast follow

Description of changes:
Refactor the soft DELETE Project API to use MetadataService since there is common code

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.