### PR TITLE
chore: allow merge commits to feat/* branches

### DIFF
--- a/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
+++ b/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
@@ -11,8 +11,8 @@ on:
       pr_number:
         description: PR number to merge
         required: true
-      destination_feat_branch:
-        description: feat branch name to merge to (exclude 'feat/' from the name)
+      target_feat_branch:
+        description: feat branch name to merge to
         required: true
 
 jobs:
@@ -24,7 +24,7 @@ jobs:
         uses: tj-actions/branch-names@v5.1
 
       - name: enable merge commits
-        if: steps.branch_name.outputs.base_ref_branch == "feat/${{ inputs.destination_feat_branch }}"
+        if: startsWith(steps.branch_name.outputs.base_ref_branch, 'feat/') && steps.branch_name.outputs.base_ref_branch == inputs.target_feat_branch
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
@@ -35,7 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: merge commit topic branches pr to feat/*
-        if: steps.branch_name.outputs.base_ref_branch == "feat/${{ inputs.destination_feat_branch }}"
+        if: startsWith(steps.branch_name.outputs.base_ref_branch, 'feat/') && steps.branch_name.outputs.base_ref_branch == inputs.target_feat_branch
         uses: octokit/request-action@v2.x
         with:
           route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge

--- a/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
+++ b/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
@@ -6,17 +6,14 @@
 name: Merge-commit-topic-branch-pr-to-feat-branches
 
 on:
-  push:
   workflow_dispatch:
     inputs:
       pr_number:
         description: PR number to merge
         required: true
-        default: '9999'
-      feat_branch_name:
+      destination_feat_branch:
         description: feat branch name to merge to (exclude 'feat/' from the name)
         required: true
-        default: 'test'
 
 jobs:
   merge-commit-topic-branch-pr-to-feat-branches:
@@ -26,39 +23,36 @@ jobs:
         id: branch-name
         uses: tj-actions/branch-names@v5.1
 
-      - name: echo
-        run: |
-          echo "feat/${{ inputs.feat_branch_name }}"
+      - name: enable merge commits
+        if: steps.branch_name.outputs.base_ref_branch == "feat/${{ inputs.destination_feat_branch }}"
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/{owner}/{repo}
+          owner: aws-solutions
+          repo: solution-spark-on-aws
+          allow_merge_commit: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
-      # - name: enable merge commits
-      #   if: startsWith(steps.branch_name.outputs.base_ref_branch, "feat/${{ inputs.feat_branch }}")
-      #   uses: octokit/request-action@v2.x
-      #   with:
-      #     route: PATCH /repos/{owner}/{repo}
-      #     owner: aws-solutions
-      #     repo: solution-spark-on-aws
-      #     allow_merge_commit: true
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+      - name: merge commit topic branches pr to feat/*
+        if: steps.branch_name.outputs.base_ref_branch == "feat/${{ inputs.destination_feat_branch }}"
+        uses: octokit/request-action@v2.x
+        with:
+          route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
+          owner: aws-solutions
+          repo: solution-spark-on-aws
+          pull_number: ${{ inputs.pr_number }}
+          merge_method: 'merge'
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
-      # - name: merge commit topic branches pr to feat/*
-      #   if: startsWith(steps.branch_name.outputs.base_ref_branch, ${{ inputs.base_branch }})
-      #   uses: octokit/request-action@v2.x
-      #   with:
-      #     route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
-      #     owner: aws-solutions
-      #     repo: solution-spark-on-aws
-      #     pull_number: ${{ inputs.pr_number }}
-      #     merge_method: 'merge'
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
-
-      # - name: disable merge commits
-      #   uses: octokit/request-action@v2.x
-      #   with:
-      #     route: PATCH /repos/{owner}/{repo}
-      #     owner: aws-solutions
-      #     repo: solution-spark-on-aws
-      #     allow_merge_commit: false
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+      - name: disable merge commits
+        if: always()
+        uses: octokit/request-action@v2.x
+        with:
+          route: PATCH /repos/{owner}/{repo}
+          owner: aws-solutions
+          repo: solution-spark-on-aws
+          allow_merge_commit: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}

--- a/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
+++ b/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
@@ -19,12 +19,25 @@ jobs:
   merge-commit-topic-branch-pr-to-feat-branches:
     runs-on: ubuntu-20.04
     steps:
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v5.1
+      - name: Get PR info
+        id: pr_info
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/{owner}/{repo}/pulls/{pull_number}
+          owner: aws-solutions
+          repo: solution-spark-on-aws
+          pull_number: ${{ inputs.pr_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+
+      - name: echo
+        run: |
+          echo ${{ fromJson(steps.pr_info.outputs.data).head.ref }}
+          echo ${{ fromJson(steps.pr_info.outputs.data).base.ref }}
+          echo "${{ inputs.target_feat_branch }}"
 
       - name: enable merge commits
-        if: startsWith(steps.branch_name.outputs.base_ref_branch, 'feat/') && steps.branch_name.outputs.base_ref_branch == inputs.target_feat_branch
+        if: startsWith(fromJson(steps.pr_info.outputs.data).base.ref, 'feat/') && fromJson(steps.pr_info.outputs.data).base.ref == inputs.target_feat_branch
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
@@ -35,7 +48,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: merge commit topic branches pr to feat/*
-        if: startsWith(steps.branch_name.outputs.base_ref_branch, 'feat/') && steps.branch_name.outputs.base_ref_branch == inputs.target_feat_branch
+        if: startsWith(fromJson(steps.pr_info.outputs.data).base.ref, 'feat/') && fromJson(steps.pr_info.outputs.data).base.ref == inputs.target_feat_branch
         uses: octokit/request-action@v2.x
         with:
           route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge

--- a/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
+++ b/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
@@ -1,0 +1,66 @@
+#
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+#
+
+name: Merge-commit-topic-branch-pr-to-feat-branches
+
+on:
+  push:
+    branches:
+      - "allow-merge-commit-on-feat"
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to merge
+        required: true
+        default: '9999'
+      feat_branch_name:
+        description: feat branch name to merge to (exclude 'feat/' from the name)
+        required: true
+        default: 'test'
+
+jobs:
+  merge-commit-topic-branch-pr-to-feat-branches:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v5.1
+
+      - name: echo
+        run: |
+          echo ${{ steps.branch_name.outputs }}
+
+      # - name: enable merge commits
+      #   if: startsWith(steps.branch_name.outputs.base_ref_branch, "feat/${{ inputs.feat_branch }}")
+      #   uses: octokit/request-action@v2.x
+      #   with:
+      #     route: PATCH /repos/{owner}/{repo}
+      #     owner: aws-solutions
+      #     repo: solution-spark-on-aws
+      #     allow_merge_commit: true
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+
+      # - name: merge commit topic branches pr to feat/*
+      #   if: startsWith(steps.branch_name.outputs.base_ref_branch, ${{ inputs.base_branch }})
+      #   uses: octokit/request-action@v2.x
+      #   with:
+      #     route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
+      #     owner: aws-solutions
+      #     repo: solution-spark-on-aws
+      #     pull_number: ${{ inputs.pr_number }}
+      #     merge_method: 'merge'
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
+
+      # - name: disable merge commits
+      #   uses: octokit/request-action@v2.x
+      #   with:
+      #     route: PATCH /repos/{owner}/{repo}
+      #     owner: aws-solutions
+      #     repo: solution-spark-on-aws
+      #     allow_merge_commit: false
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}

--- a/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
+++ b/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
@@ -30,12 +30,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
-      - name: echo
-        run: |
-          echo ${{ fromJson(steps.pr_info.outputs.data).head.ref }}
-          echo ${{ fromJson(steps.pr_info.outputs.data).base.ref }}
-          echo "${{ inputs.target_feat_branch }}"
-
       - name: enable merge commits
         if: startsWith(fromJson(steps.pr_info.outputs.data).base.ref, 'feat/') && fromJson(steps.pr_info.outputs.data).base.ref == inputs.target_feat_branch
         uses: octokit/request-action@v2.x

--- a/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
+++ b/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: echo
         run: |
-          echo ${{ steps.branch_name.outputs }}
+          echo "feat/${{ inputs.feat_branch_name }}"
 
       # - name: enable merge commits
       #   if: startsWith(steps.branch_name.outputs.base_ref_branch, "feat/${{ inputs.feat_branch }}")

--- a/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
+++ b/.github/workflows/merge-commit-topic-branch-pr-to-feat-branch.yml
@@ -7,8 +7,6 @@ name: Merge-commit-topic-branch-pr-to-feat-branches
 
 on:
   push:
-    branches:
-      - "allow-merge-commit-on-feat"
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/merge-release-pr-to-main.yml
+++ b/.github/workflows/merge-release-pr-to-main.yml
@@ -22,12 +22,19 @@ jobs:
           require: 'admin'
           username: ${{ github.triggering_actor }}
 
-      - name: Get branch name
-        id: branch-name
-        uses: tj-actions/branch-names@v5.1
+      - name: Get PR info
+        id: pr_info
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/{owner}/{repo}/pulls/{pull_number}
+          owner: aws-solutions
+          repo: solution-spark-on-aws
+          pull_number: ${{ inputs.pr_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: enable merge commits
-        if: steps.check_admin.outputs.require-result && startsWith(steps.branch_name.outputs.head_ref_branch, 'release/') && steps.branch_name.outputs.base_ref_branch == 'main'
+        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.pr_info.outputs.data).head.ref, 'release/') && fromJson(steps.pr_info.outputs.data).base.ref == 'main'
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}
@@ -38,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: merge release branch pr to main
-        if: steps.check_admin.outputs.require-result && startsWith(steps.branch_name.outputs.head_ref_branch, 'release/') && steps.branch_name.outputs.base_ref_branch == 'main'
+        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.pr_info.outputs.data).head.ref, 'release/') && fromJson(steps.pr_info.outputs.data).base.ref == 'main'
         uses: octokit/request-action@v2.x
         with:
           route: PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge
@@ -50,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.MERGE_TOKEN }}
 
       - name: disable merge commits
-        if: steps.check_admin.outputs.require-result && startsWith(steps.branch_name.outputs.head_ref_branch, 'release/') && steps.branch_name.outputs.base_ref_branch == 'main'
+        if: steps.check_admin.outputs.require-result && startsWith(fromJson(steps.pr_info.outputs.data).head.ref, 'release/') && fromJson(steps.pr_info.outputs.data).base.ref == 'main'
         uses: octokit/request-action@v2.x
         with:
           route: PATCH /repos/{owner}/{repo}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
1. Adds a workflow (`merge-commit-topic-branch-pr-to-feat-branch.yml`) that can be triggered manually to perform merge commits from topic branches to feat/* branches
2. Fix for `merge-release-pr-to-main.yml` workflow: `tj-actions/branch-names` github action does not work on workflow_dispatch event

Note:
`merge-commit-topic-branch-pr-to-feat-branch.yml` workflow won't be activated on github UI until this workflow is merged to `main` branch. As a workaround you can install [gh cli](https://cli.github.com/) and trigger the following command when you need to perform merge commits on feat/* branches from your topic branch: `gh workflow run 'Merge-commit-topic-branch-pr-to-feat-branches' --ref <TOPIC_BRANCH_NAME> -f pr_number=<PR_NUMBER> -f target_feat_branch=<TARGET_FEAT_BRANCH_NAME>`

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.