### PR TITLE
feat(workbench-core/datasets): BREAKING CHANGE - add fileName param to DatasetService.createPresignedUploadUrl() and add datasets presigned singe file upload integ tests

### DIFF
--- a/common/changes/@aws/workbench-core-base/topic-presigned-file-upload-integ-tests_2022-12-01-23-00.json
+++ b/common/changes/@aws/workbench-core-base/topic-presigned-file-upload-integ-tests_2022-12-01-23-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "Refactored `createPresignedUploadUrl` helper function.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/common/changes/@aws/workbench-core-datasets/topic-presigned-file-upload-integ-tests_2022-12-01-23-00.json
+++ b/common/changes/@aws/workbench-core-datasets/topic-presigned-file-upload-integ-tests_2022-12-01-23-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-datasets",
+      "comment": "Added `fileName` parameter to `createPresignedUploadUrl` function",
+      "type": "major"
+    }
+  ],
+  "packageName": "@aws/workbench-core-datasets"
+}

--- a/workbench-core/base/src/aws/helpers/s3Service.ts
+++ b/workbench-core/base/src/aws/helpers/s3Service.ts
@@ -5,7 +5,7 @@
 
 import fs from 'fs';
 import { join } from 'path';
-import { PutObjectCommand, S3, S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
+import { PutObjectCommand, S3 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 
 export default class S3Service {
@@ -89,15 +89,8 @@ export default class S3Service {
     prefix: string,
     timeToLiveSeconds: number
   ): Promise<string> {
-    const config: S3ClientConfig = {
-      credentials: await this._s3.config.credentials(),
-      region: this._s3.config.region
-    };
-
-    return await getSignedUrl(
-      new S3Client(config),
-      new PutObjectCommand({ Bucket: s3BucketName, Key: prefix }),
-      { expiresIn: timeToLiveSeconds }
-    );
+    return await getSignedUrl(this._s3, new PutObjectCommand({ Bucket: s3BucketName, Key: prefix }), {
+      expiresIn: timeToLiveSeconds
+    });
   }
 }

--- a/workbench-core/datasets/src/dataSetService.test.ts
+++ b/workbench-core/datasets/src/dataSetService.test.ts
@@ -621,9 +621,10 @@ describe('DataSetService', () => {
 
     it('returns a presigned URL.', async () => {
       const ttlSeconds = 3600;
+      const fileName = 'test.txt';
 
       await expect(
-        service.getPresignedSinglePartUploadUrl(mockDataSetId, ttlSeconds, plugin)
+        service.getPresignedSinglePartUploadUrl(mockDataSetId, fileName, ttlSeconds, plugin)
       ).resolves.toEqual(mockPresignedSinglePartUploadURL);
     });
   });

--- a/workbench-core/datasets/src/dataSetService.ts
+++ b/workbench-core/datasets/src/dataSetService.ts
@@ -320,18 +320,20 @@ export class DataSetService {
   /**
    * Create a presigned URL for a signle-part file upload
    * @param datasetId - the ID of the Dataset.
+   * @param fileName - the name of the file to upload.
    * @param timeToLiveSeconds - length of time (in seconds) the URL is valid.
    * @param storageProvider - an instance of DataSetsStoragePlugin intialized to access the endpoint.
    * @returns the presigned URL
    */
   public async getPresignedSinglePartUploadUrl(
     datasetId: string,
+    fileName: string,
     timeToLiveSeconds: number,
     storageProvider: DataSetsStoragePlugin
   ): Promise<string> {
     const dataset = await this.getDataSet(datasetId);
 
-    return await storageProvider.createPresignedUploadUrl(dataset, timeToLiveSeconds);
+    return await storageProvider.createPresignedUploadUrl(dataset, fileName, timeToLiveSeconds);
   }
 
   /**

--- a/workbench-core/datasets/src/dataSetsStoragePlugin.ts
+++ b/workbench-core/datasets/src/dataSetsStoragePlugin.ts
@@ -130,11 +130,12 @@ export interface DataSetsStoragePlugin {
    * Create a presigned URL to be used to upload a file to a Dataset.
    *
    * @param dataset - the Dataset to which to make an upload.
+   * @param fileName - the name of the file to upload.
    * @param timeToLiveSeconds - the maximum time before the URL expires.
    *
    * @returns a URL which can be used to upload a file directly to the DataSet destination.
    */
-  createPresignedUploadUrl(dataset: DataSet, timeToLiveSeconds: number): Promise<string>;
+  createPresignedUploadUrl(dataset: DataSet, fileName: string, timeToLiveSeconds: number): Promise<string>;
 
   /**
    * Create a set of presigned URLs to be used to make a multipart upload to a DataSet.

--- a/workbench-core/datasets/src/index.ts
+++ b/workbench-core/datasets/src/index.ts
@@ -5,6 +5,7 @@
 
 import CreateDataSetSchema from './schemas/createDataSet';
 import CreateExternalEndpointSchema from './schemas/createExternalEndpoint';
+import CreatePresignedSinglePartFileUploadUrl from './schemas/createPresignedSinglePartFileUploadUrl';
 
 export { DataSet } from './dataSet';
 export { DataSetMetadataPlugin } from './dataSetMetadataPlugin';
@@ -18,7 +19,7 @@ export { InvalidIamRoleError, isInvalidIamRoleError } from './errors/invalidIamR
 export { ExternalEndpoint } from './externalEndpoint';
 export { IamHelper } from './awsUtilities/iamHelper';
 export { S3DataSetStoragePlugin } from './s3DataSetStoragePlugin';
-export { CreateDataSetSchema, CreateExternalEndpointSchema };
+export { CreateDataSetSchema, CreateExternalEndpointSchema, CreatePresignedSinglePartFileUploadUrl };
 export { StorageLocation } from './storageLocation';
 export {
   addDatasetPermissionsToRole,

--- a/workbench-core/datasets/src/s3DataSetStoragePlugin.test.ts
+++ b/workbench-core/datasets/src/s3DataSetStoragePlugin.test.ts
@@ -940,9 +940,11 @@ describe('S3DataSetStoragePlugin', () => {
   describe('createPresignedUploadUrl', () => {
     it('returns a presigned url for a single part file upload', async () => {
       const ttl = 3600;
+      const fileName = 'test.txt';
 
       const url = await plugin.createPresignedUploadUrl(
         { name: path, storageName: name, path, storageType: 'S3' },
+        fileName,
         ttl
       );
 

--- a/workbench-core/datasets/src/s3DataSetStoragePlugin.ts
+++ b/workbench-core/datasets/src/s3DataSetStoragePlugin.ts
@@ -148,10 +148,14 @@ export class S3DataSetStoragePlugin implements DataSetsStoragePlugin {
     throw new Error('Method not implemented.');
   }
 
-  public async createPresignedUploadUrl(dataset: DataSet, timeToLiveSeconds: number): Promise<string> {
+  public async createPresignedUploadUrl(
+    dataset: DataSet,
+    fileName: string,
+    timeToLiveSeconds: number
+  ): Promise<string> {
     return await this._aws.helpers.s3.createPresignedUploadUrl(
       dataset.storageName,
-      dataset.name,
+      `${dataset.name}/${fileName}`,
       timeToLiveSeconds
     );
   }

--- a/workbench-core/datasets/src/schemas/createPresignedSinglePartFileUploadUrl.ts
+++ b/workbench-core/datasets/src/schemas/createPresignedSinglePartFileUploadUrl.ts
@@ -1,0 +1,19 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+// Schema for createExternalEndpoint API
+import { Schema } from 'jsonschema';
+
+const CreatePresignedSinglePartFileUploadUrl: Schema = {
+  id: '/createPresignedSinglePartFileUploadUrl',
+  type: 'object',
+  properties: {
+    fileName: { type: 'string' }
+  },
+  additionalProperties: false,
+  required: ['fileName']
+};
+
+export default CreatePresignedSinglePartFileUploadUrl;

--- a/workbench-core/example/app/src/configs/staticPermissionsConfig.ts
+++ b/workbench-core/example/app/src/configs/staticPermissionsConfig.ts
@@ -48,6 +48,11 @@ const adminPermissions: Permission[] = [
   },
   {
     effect: 'ALLOW',
+    action: 'CREATE',
+    subject: 'DatasetFile'
+  },
+  {
+    effect: 'ALLOW',
     action: 'READ',
     subject: 'Role'
   },

--- a/workbench-core/example/app/src/configs/staticRouteConfig.ts
+++ b/workbench-core/example/app/src/configs/staticRouteConfig.ts
@@ -60,6 +60,14 @@ export const routesMap: RoutesMap = {
       }
     ]
   },
+  [`/datasets/${dataSetPrefix.toLowerCase()}-${uuidRegExpAsString}/presignedUpload`]: {
+    POST: [
+      {
+        action: 'CREATE',
+        subject: 'DatasetFile'
+      }
+    ]
+  },
   [`/datasets/${dataSetPrefix.toLowerCase()}-${uuidRegExpAsString}}/share/${endPointPrefix.toLowerCase()}-${uuidRegExpAsString}`]:
     {
       DELETE: [

--- a/workbench-core/example/app/src/routes/datasetRoutes.ts
+++ b/workbench-core/example/app/src/routes/datasetRoutes.ts
@@ -7,6 +7,7 @@ import { uuidWithLowercasePrefixRegExp } from '@aws/workbench-core-base';
 import {
   CreateDataSetSchema,
   CreateExternalEndpointSchema,
+  CreatePresignedSinglePartFileUploadUrl,
   DataSetService,
   DataSetsStoragePlugin,
   isDataSetHasEndpointError
@@ -17,6 +18,8 @@ import { validate } from 'jsonschema';
 import { dataSetPrefix, endPointPrefix } from '../configs/constants';
 import { wrapAsync } from '../utilities/errorHandlers';
 import { processValidatorResult } from '../utilities/validatorHelper';
+
+const timeToLiveSeconds: number = 60 * 1; // 1 minute
 
 export function setUpDSRoutes(
   router: Router,
@@ -95,7 +98,26 @@ export function setUpDSRoutes(
     })
   );
 
-  // List storag locations
+  // Get presigned single part file upload URL
+  router.post(
+    '/datasets/:datasetId/presignedUpload',
+    wrapAsync(async (req: Request, res: Response) => {
+      if (req.params.datasetId.match(uuidWithLowercasePrefixRegExp(dataSetPrefix)) === null) {
+        throw Boom.badRequest('datasetId request parameter is invalid');
+      }
+      processValidatorResult(validate(req.body, CreatePresignedSinglePartFileUploadUrl));
+
+      const url = await dataSetService.getPresignedSinglePartUploadUrl(
+        req.params.datasetId,
+        req.body.fileName,
+        timeToLiveSeconds,
+        dataSetStoragePlugin
+      );
+      res.status(200).send({ url });
+    })
+  );
+
+  // List storage locations
   router.get(
     '/datasets/storage',
     wrapAsync(async (req: Request, res: Response) => {

--- a/workbench-core/example/infrastructure/integration-tests/support/complex/datasetHelper.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/complex/datasetHelper.ts
@@ -18,6 +18,12 @@ export class DatasetHelper {
     return response.AccessPointList!;
   }
 
+  public async listDatasetFileNames(bucket: string, dir: string): Promise<string[]> {
+    const response = await this._awsSdk.clients.s3.listObjectsV2({ Bucket: bucket, Prefix: dir });
+
+    return response.Contents?.map((file) => file.Key ?? '') ?? [];
+  }
+
   public async deleteS3AccessPoint(name: string, bucketAccount: string): Promise<void> {
     await this._awsSdk.clients.s3Control.deleteAccessPoint({
       Name: name,

--- a/workbench-core/example/infrastructure/integration-tests/support/resources/datasets/dataset.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/resources/datasets/dataset.ts
@@ -67,7 +67,7 @@ export default class Dataset extends Resource {
     return response;
   }
 
-  public async singlePartFileUploadUrl(body: { fileName: string }): Promise<AxiosResponse> {
+  public async generateSinglePartFileUploadUrl(body: { fileName: string }): Promise<AxiosResponse> {
     return await this._axiosInstance.post(`${this._api}/presignedUpload`, body);
   }
 

--- a/workbench-core/example/infrastructure/integration-tests/support/resources/datasets/dataset.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/resources/datasets/dataset.ts
@@ -12,18 +12,18 @@ import Endpoint, { EndpointCreateParams } from './endpoint';
 
 export default class Dataset extends Resource {
   private _awsAccountId: string;
-  private _storageName: string;
-  private _storagePath: string;
   private _children: Map<string, Endpoint>;
 
   private _clientSession: ClientSession;
   public id: string;
+  public storageName: string;
+  public storagePath: string;
 
   public constructor(params: DataSetCreateParams) {
     super(params.clientSession, 'dataset', params.id, params.parentApi);
     this._awsAccountId = params.awsAccountId;
-    this._storageName = params.storageName;
-    this._storagePath = params.storagePath;
+    this.storageName = params.storageName;
+    this.storagePath = params.storagePath;
     this.id = params.id;
     this._api = `datasets/${params.id}`;
     this._clientSession = params.clientSession;
@@ -67,11 +67,15 @@ export default class Dataset extends Resource {
     return response;
   }
 
+  public async singlePartFileUploadUrl(body: { fileName: string }): Promise<AxiosResponse> {
+    return await this._axiosInstance.post(`${this._api}/presignedUpload`, body);
+  }
+
   public async cleanup(): Promise<void> {
     try {
       // Delete DDB entries, and path folder from bucket (to prevent test resources polluting a prod env)
       const datasetHelper = new DatasetHelper();
-      await datasetHelper.deleteS3Resources(this._storageName, this._storagePath);
+      await datasetHelper.deleteS3Resources(this.storageName, this.storagePath);
       await datasetHelper.deleteDdbRecords(this.id);
     } catch (error) {
       console.warn(`Error caught in cleanup of dataset '${this.id}': ${error}.`);

--- a/workbench-core/example/infrastructure/integration-tests/support/resources/datasets/datasets.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/resources/datasets/datasets.ts
@@ -14,8 +14,8 @@ export default class Datasets extends CollectionResource {
     this._api = 'datasets';
   }
 
-  public dataset(params: DataSetCreateParams): Dataset {
-    return new Dataset(params);
+  public dataset(params: Omit<DataSetCreateParams, 'clientSession' | 'parentApi'>): Dataset {
+    return new Dataset({ ...params, clientSession: this._clientSession, parentApi: this._parentApi });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -27,10 +27,8 @@ export default class Datasets extends CollectionResource {
     const requestBody = applyDefault ? this._buildDefaults(body) : body;
     const response: AxiosResponse = await this._axiosInstance.post(this._api, requestBody);
 
-    const createParams: DataSetCreateParams = {
+    const createParams = {
       id: response.data.id,
-      clientSession: this._clientSession,
-      parentApi: 'datasets',
       awsAccountId: response.data.awsAccountId,
       storageName: response.data.storageName,
       storagePath: response.data.path

--- a/workbench-core/example/infrastructure/integration-tests/tests/datasets/fileUpload.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/datasets/fileUpload.test.ts
@@ -1,0 +1,90 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import { v4 as uuidv4 } from 'uuid';
+import ClientSession from '../../support/clientSession';
+import { DatasetHelper } from '../../support/complex/datasetHelper';
+import Dataset from '../../support/resources/datasets/dataset';
+import Setup from '../../support/setup';
+import HttpError from '../../support/utils/HttpError';
+
+describe('datasets list integration test', () => {
+  const setup: Setup = new Setup();
+  let adminSession: ClientSession;
+
+  const fakeDataSetId: string = 'example-ds-badbadba-dbad-badb-adba-dbadbadbadba';
+
+  beforeEach(() => {
+    expect.hasAssertions();
+  });
+
+  beforeAll(async () => {
+    try {
+      adminSession = await setup.getDefaultAdminSession();
+    } catch (e) {
+      console.log(e);
+    }
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  describe('PresignedSinglePartUpload', () => {
+    let dataset: Dataset;
+
+    beforeAll(async () => {
+      const {
+        data: { id }
+      } = await adminSession.resources.datasets.create({}, true);
+      dataset = adminSession.resources.datasets.children.get(id) as Dataset;
+    });
+
+    it('generates a presigned URL and uplaod a file using that URL', async () => {
+      const fileName = uuidv4();
+      const response = await dataset.singlePartFileUploadUrl({ fileName });
+
+      await adminSession.getAxiosInstance().put(response.data.url, { fake: 'data' });
+
+      const dsHelper = new DatasetHelper();
+      const files = await dsHelper.listDatasetFileNames(dataset.storageName, dataset.storagePath);
+      expect(files.length > 0).toBe(true);
+      expect(files).toContain(`${dataset.storagePath}/${fileName}`);
+    });
+
+    it('throws when generating a URL for a dataset that doesnt exist', async () => {
+      const dataset = adminSession.resources.datasets.dataset({
+        id: fakeDataSetId,
+        awsAccountId: '',
+        storageName: '',
+        storagePath: ''
+      });
+      await expect(dataset.singlePartFileUploadUrl({ fileName: '' })).rejects.toThrow(new HttpError(404, {}));
+    });
+
+    it('throws when generating a URL for a dataset with an invalid id', async () => {
+      const dataset = adminSession.resources.datasets.dataset({
+        id: 'fakeDataSetId',
+        awsAccountId: '',
+        storageName: '',
+        storagePath: ''
+      });
+      await expect(dataset.singlePartFileUploadUrl({ fileName: '' })).rejects.toThrow(new HttpError(403, {}));
+    });
+
+    it('throws when the fileName is missing in the request body', async () => {
+      const invalidRequest: Record<string, unknown> = {};
+      await expect(dataset.singlePartFileUploadUrl(invalidRequest as { fileName: string })).rejects.toThrow(
+        new HttpError(400, {})
+      );
+    });
+
+    it('throws when the fileName in the request body is not a string', async () => {
+      const invalidRequest: Record<string, unknown> = { fileName: 123 };
+      await expect(dataset.singlePartFileUploadUrl(invalidRequest as { fileName: string })).rejects.toThrow(
+        new HttpError(400, {})
+      );
+    });
+  });
+});

--- a/workbench-core/example/infrastructure/integration-tests/tests/datasets/fileUpload.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/datasets/fileUpload.test.ts
@@ -41,9 +41,9 @@ describe('datasets list integration test', () => {
       dataset = adminSession.resources.datasets.children.get(id) as Dataset;
     });
 
-    it('generates a presigned URL and uplaod a file using that URL', async () => {
+    it('generates a presigned URL and upload a file using that URL', async () => {
       const fileName = uuidv4();
-      const response = await dataset.singlePartFileUploadUrl({ fileName });
+      const response = await dataset.generateSinglePartFileUploadUrl({ fileName });
 
       await adminSession.getAxiosInstance().put(response.data.url, { fake: 'data' });
 
@@ -60,7 +60,9 @@ describe('datasets list integration test', () => {
         storageName: '',
         storagePath: ''
       });
-      await expect(dataset.singlePartFileUploadUrl({ fileName: '' })).rejects.toThrow(new HttpError(404, {}));
+      await expect(dataset.generateSinglePartFileUploadUrl({ fileName: '' })).rejects.toThrow(
+        new HttpError(404, {})
+      );
     });
 
     it('throws when generating a URL for a dataset with an invalid id', async () => {
@@ -70,21 +72,23 @@ describe('datasets list integration test', () => {
         storageName: '',
         storagePath: ''
       });
-      await expect(dataset.singlePartFileUploadUrl({ fileName: '' })).rejects.toThrow(new HttpError(403, {}));
+      await expect(dataset.generateSinglePartFileUploadUrl({ fileName: '' })).rejects.toThrow(
+        new HttpError(403, {})
+      );
     });
 
     it('throws when the fileName is missing in the request body', async () => {
       const invalidRequest: Record<string, unknown> = {};
-      await expect(dataset.singlePartFileUploadUrl(invalidRequest as { fileName: string })).rejects.toThrow(
-        new HttpError(400, {})
-      );
+      await expect(
+        dataset.generateSinglePartFileUploadUrl(invalidRequest as { fileName: string })
+      ).rejects.toThrow(new HttpError(400, {}));
     });
 
     it('throws when the fileName in the request body is not a string', async () => {
       const invalidRequest: Record<string, unknown> = { fileName: 123 };
-      await expect(dataset.singlePartFileUploadUrl(invalidRequest as { fileName: string })).rejects.toThrow(
-        new HttpError(400, {})
-      );
+      await expect(
+        dataset.generateSinglePartFileUploadUrl(invalidRequest as { fileName: string })
+      ).rejects.toThrow(new HttpError(400, {}));
     });
   });
 });


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- BREAKING CHANGE: add `fileName` param to `DatasetService.createPresignedUploadUrl()`
- added integration tests for `DatasetService.getPresignedSinglePartUploadUrl()`

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.