### PR TITLE
feat: GALI-2036 update account

### DIFF
--- a/solutions/swb-app/src/accountRoutes.ts
+++ b/solutions/swb-app/src/accountRoutes.ts
@@ -66,16 +66,10 @@ export function setUpAccountRoutes(router: Router, hostingAccountService: Hostin
     '/awsAccounts/:id',
     wrapAsync(async (req: Request, res: Response) => {
       processValidatorResult(validate(req.body, UpdateAccountSchema));
-      const { name, awsAccountId, envMgmtRoleArn, hostingAccountHandlerRoleArn, externalId } = req.body;
+      const { name } = req.body;
       const updateAccountMetadata: UpdateAccountData = {
         id: escape(req.params.id),
-        name: name!! ? escape(name) : undefined,
-        awsAccountId: awsAccountId!! ? escape(awsAccountId) : undefined,
-        envMgmtRoleArn: envMgmtRoleArn!! ? escape(envMgmtRoleArn) : undefined,
-        hostingAccountHandlerRoleArn: hostingAccountHandlerRoleArn!!
-          ? escape(hostingAccountHandlerRoleArn)
-          : undefined,
-        externalId: externalId!! ? escape(externalId) : undefined
+        name: name!! ? escape(name) : undefined
       };
 
       const updatedAccount = await hostingAccountService.update(updateAccountMetadata);

--- a/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/update.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/update.test.ts
@@ -40,11 +40,7 @@ describe('awsAccounts update negative tests', () => {
 
           await account.update(
             {
-              name: surpriseIntValue,
-              awsAccountId: surpriseIntValue,
-              envMgmtRoleArn: surpriseIntValue,
-              hostingAccountHandlerRoleArn: surpriseIntValue,
-              externalId: surpriseIntValue
+              name: surpriseIntValue
             },
             true
           );
@@ -54,8 +50,7 @@ describe('awsAccounts update negative tests', () => {
             new HttpError(400, {
               statusCode: 400,
               error: 'Bad Request',
-              message:
-                "name is not of a type(s) string. is not allowed to have the additional property 'awsAccountId'. is not allowed to have the additional property 'envMgmtRoleArn'. is not allowed to have the additional property 'hostingAccountHandlerRoleArn'. is not allowed to have the additional property 'externalId'"
+              message: 'name is not of a type(s) string'
             })
           );
         }

--- a/workbench-core/accounts/README.md
+++ b/workbench-core/accounts/README.md
@@ -7,5 +7,5 @@
 
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-93.27%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-91.04%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-92.42%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.21%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-93.23%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-90.9%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-92.42%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.17%25-brightgreen.svg?style=flat) |
 

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.test.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.test.ts
@@ -149,11 +149,7 @@ describe('HostingAccountLifecycleService', () => {
     await expect(
       hostingAccountLifecycleService.updateAccount({
         id: 'abc-xyz',
-        name: 'someName',
-        awsAccountId: '123456789012',
-        envMgmtRoleArn: 'arn:aws:iam::123456789012:role/swb-swbv2-va-env-mgmt',
-        hostingAccountHandlerRoleArn: 'arn:aws:iam::123456789012:role/swb-swbv2-va-hosting-account-role',
-        externalId: 'someExternalId'
+        name: 'someName'
       })
     ).resolves.not.toThrowError();
   });

--- a/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/accounts/src/utilities/hostingAccountLifecycleService.ts
@@ -41,10 +41,6 @@ export interface CreateAccountData {
 export interface UpdateAccountData {
   id: string;
   name?: string;
-  awsAccountId?: string;
-  envMgmtRoleArn?: string;
-  hostingAccountHandlerRoleArn?: string;
-  externalId?: string;
 }
 
 export default class HostingAccountLifecycleService {
@@ -135,13 +131,6 @@ export default class HostingAccountLifecycleService {
   }
 
   public async updateAccount(accountMetadata: UpdateAccountData): Promise<{ [key: string]: string }> {
-    if (accountMetadata.awsAccountId) {
-      await this._attachAwsAccount({
-        awsAccountId: accountMetadata.awsAccountId,
-        arns: await this._getArns()
-      });
-    }
-
     return this._accountService.update({
       ...accountMetadata
     });


### PR DESCRIPTION
Issue #, if available:
GALI-2036

Description of changes:
Make `name` the only param that can be updated on an account

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.