### PR TITLE
docs(readme.md): adding jq to prerequisites

### DIFF
--- a/workbench-core/example/infrastructure/README.md
+++ b/workbench-core/example/infrastructure/README.md
@@ -11,6 +11,7 @@
  2. `rush cinstall`
  3. `rush build:test -t @aws/workbench-core-example-infrastructure`
  4. Configure AWS Credentials locally for your AWS Account: either `export the credentials` or on the command line, set your [credential file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to have your `account` as the `default` profile
+ 5. Install [jq](https://stedolan.github.io/jq/) command line tool (required for `./scripts/getResources.sh` script)
 
  ## Setup your environment for Integration Test
  Navigate to `workbench-core/example/infrastructure`

--- a/workbench-core/example/infrastructure/README.md
+++ b/workbench-core/example/infrastructure/README.md
@@ -11,7 +11,8 @@
  2. `rush cinstall`
  3. `rush build:test -t @aws/workbench-core-example-infrastructure`
  4. Configure AWS Credentials locally for your AWS Account: either `export the credentials` or on the command line, set your [credential file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to have your `account` as the `default` profile
- 5. Install [jq](https://stedolan.github.io/jq/) command line tool (required for `./scripts/getResources.sh` script)
+ 5. Install [jq](https://stedolan.github.io/jq/) command line tool (required for `./scripts/getResources.sh` script) by running e.g. `brew install jq`
+ 6. Install [AWS Command Line Interface](https://aws.amazon.com/cli/)
 
  ## Setup your environment for Integration Test
  Navigate to `workbench-core/example/infrastructure`

--- a/workbench-core/example/infrastructure/README.md
+++ b/workbench-core/example/infrastructure/README.md
@@ -12,7 +12,7 @@
  3. `rush build:test -t @aws/workbench-core-example-infrastructure`
  4. Configure AWS Credentials locally for your AWS Account: either `export the credentials` or on the command line, set your [credential file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) to have your `account` as the `default` profile
  5. Install [jq](https://stedolan.github.io/jq/) command line tool (required for `./scripts/getResources.sh` script) by running e.g. `brew install jq`
- 6. Install [AWS Command Line Interface](https://aws.amazon.com/cli/)
+ 6. Install [AWS Command Line Interface](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
 
  ## Setup your environment for Integration Test
  Navigate to `workbench-core/example/infrastructure`


### PR DESCRIPTION
Script getResource.sh requires jq to run correctly; this tool is not mentioned in prerequisites

Issue #, if available: N/A

Description of changes:

Aadding [jq](https://stedolan.github.io/jq/) CLI tool to prerequisites step of workbench-core/example/infrastructure/README.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.