### PR TITLE
fix(swb): fix accountId needed for using an existing VPC and update AccessLog Cfn Export name

### DIFF
--- a/solutions/swb-reference/src/SWBStack.ts
+++ b/solutions/swb-reference/src/SWBStack.ts
@@ -117,8 +117,11 @@ export class SWBStack extends Stack {
       ALB_INTERNET_FACING
     } = getConstants();
 
+    const MAIN_ACCT_ID: string = process.env.CDK_DEFAULT_ACCOUNT || '';
+
     super(app, STACK_NAME, {
       env: {
+        account: MAIN_ACCT_ID,
         region: AWS_REGION
       }
     });
@@ -148,7 +151,6 @@ export class SWBStack extends Stack {
 
     // We extract a subset of constants required to be set on Lambda
     // Note: AWS_REGION cannot be set since it's a reserved env variable
-    const MAIN_ACCT_ID = `${this.account}`;
     this.lambdaEnvVars = {
       STAGE,
       STACK_NAME,
@@ -215,8 +217,7 @@ export class SWBStack extends Stack {
         imageScanOnPush: true
       });
       new CfnOutput(this, ECR_REPOSITORY_NAME_OUTPUT_KEY, {
-        value: repository.repositoryName,
-        exportName: ECR_REPOSITORY_NAME_OUTPUT_KEY
+        value: repository.repositoryName
       });
     } else {
       new CfnOutput(this, 'apiUrlOutput', {
@@ -306,13 +307,11 @@ export class SWBStack extends Stack {
     });
 
     new CfnOutput(this, this._swbDomainNameOutputKey, {
-      value: domainName,
-      exportName: this._swbDomainNameOutputKey
+      value: domainName
     });
 
     new CfnOutput(this, this._mainAccountLoadBalancerListenerArnOutputKey, {
-      value: alb.applicationLoadBalancer.listeners[0].listenerArn,
-      exportName: this._mainAccountLoadBalancerListenerArnOutputKey
+      value: alb.applicationLoadBalancer.listeners[0].listenerArn
     });
 
     new CfnOutput(this, 'apiUrlOutput', {

--- a/solutions/swb-reference/src/SWBStack.ts
+++ b/solutions/swb-reference/src/SWBStack.ts
@@ -119,12 +119,20 @@ export class SWBStack extends Stack {
 
     const MAIN_ACCT_ID: string = process.env.CDK_DEFAULT_ACCOUNT || '';
 
-    super(app, STACK_NAME, {
-      env: {
-        account: MAIN_ACCT_ID,
-        region: AWS_REGION
-      }
-    });
+    if (MAIN_ACCT_ID) {
+      super(app, STACK_NAME, {
+        env: {
+          account: MAIN_ACCT_ID,
+          region: AWS_REGION
+        }
+      });
+    } else {
+      super(app, STACK_NAME, {
+        env: {
+          region: AWS_REGION
+        }
+      });
+    }
 
     const workbenchCognito = this._createCognitoResources(
       COGNITO_DOMAIN,

--- a/solutions/swb-reference/src/SWBStack.ts
+++ b/solutions/swb-reference/src/SWBStack.ts
@@ -117,22 +117,12 @@ export class SWBStack extends Stack {
       ALB_INTERNET_FACING
     } = getConstants();
 
-    const MAIN_ACCT_ID: string = process.env.CDK_DEFAULT_ACCOUNT || '';
-
-    if (MAIN_ACCT_ID) {
-      super(app, STACK_NAME, {
-        env: {
-          account: MAIN_ACCT_ID,
-          region: AWS_REGION
-        }
-      });
-    } else {
-      super(app, STACK_NAME, {
-        env: {
-          region: AWS_REGION
-        }
-      });
-    }
+    super(app, STACK_NAME, {
+      env: {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: AWS_REGION
+      }
+    });
 
     const workbenchCognito = this._createCognitoResources(
       COGNITO_DOMAIN,
@@ -159,6 +149,7 @@ export class SWBStack extends Stack {
 
     // We extract a subset of constants required to be set on Lambda
     // Note: AWS_REGION cannot be set since it's a reserved env variable
+    const MAIN_ACCT_ID = `${this.account}`;
     this.lambdaEnvVars = {
       STAGE,
       STACK_NAME,

--- a/solutions/swb-reference/src/constants.ts
+++ b/solutions/swb-reference/src/constants.ts
@@ -91,7 +91,7 @@ function getConstants(): Constants {
 
   // These are the OutputKey for the SWB Main Account CFN stack
   const SSM_DOC_OUTPUT_KEY_SUFFIX = 'SSMDocOutput';
-  const S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY = 'S3BucketAccessLogsNameOutput';
+  const S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY = `${config.stage}-S3BucketAccessLogsNameOutput`;
   const S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY = 'S3BucketArtifactsArnOutput';
   const S3_DATASETS_BUCKET_ARN_OUTPUT_KEY = 'S3BucketDatasetsArnOutput';
   const LAUNCH_CONSTRAINT_ROLE_OUTPUT_KEY = 'LaunchConstraintIamRoleNameOutput';

--- a/solutions/swb-ui/infrastructure/src/constants.ts
+++ b/solutions/swb-ui/infrastructure/src/constants.ts
@@ -64,7 +64,7 @@ function getConstants(): {
   // CloudFormation Output Keys
   const S3_ARTIFACT_BUCKET_ARN_OUTPUT_KEY = 'S3BucketArtifactsArnOutput';
   // The output name below must match the value in swb-reference
-  const S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY = 'S3BucketAccessLogsNameOutput';
+  const S3_ACCESS_LOGS_BUCKET_NAME_OUTPUT_KEY = `${STAGE}-S3BucketAccessLogsNameOutput`;
 
   return {
     STAGE,

--- a/solutions/swb-ui/ui/scripts/image-deploy.sh
+++ b/solutions/swb-ui/ui/scripts/image-deploy.sh
@@ -21,9 +21,14 @@ printf "\nBuilding and deploying docker image for SWB v2.\n"
 upload_docker_image_ecr
 printf "\nCompleted deploying SWB v2 UI image to ECR.\n"
 
-printf "\nUpdating images for ECS tasks.\n"
-cluster_name="$(jq -r '.[].ecsClusterName' ../infrastructure/src/config/${STAGE}.json)"
-service_name="$(jq -r '.[].ecsServiceName' ../infrastructure/src/config/${STAGE}.json)"
-aws ecs update-service --cluster $cluster_name --service $service_name --force-new-deployment
-printf "\nCompleted updating images for ECS tasks. Exiting...\n"
+if [ ! -f ../infrastructure/src/config/${STAGE}.json ]
+then
+    printf "\nUI Infra has not been deployed yet. Skipping update on ECS tasks. Exiting...\n"
+else
+    printf "\nUpdating images for ECS tasks.\n"
+    cluster_name="$(jq -r '.[].ecsClusterName' ../infrastructure/src/config/${STAGE}.json)"
+    service_name="$(jq -r '.[].ecsServiceName' ../infrastructure/src/config/${STAGE}.json)"
+    aws ecs update-service --cluster $cluster_name --service $service_name --force-new-deployment
+    printf "\nCompleted updating images for ECS tasks. Exiting...\n"
+fi
 


### PR DESCRIPTION
BREAKING CHANGE: UI stack uses previous Cfn Export name, which requires UI stack to be deleted prior to updating swb-reference

Issue #, if available:

Description of changes:
* Update account id to be grabbed from env so that existing VPC can be used in SWB
* Update Cfn Export name for Access Log Bucket to allow for multiple installations of SWB in the same region in the same account

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.