### PR TITLE
chore(et and etc): add integration tests and delete create et API

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -218,6 +218,7 @@ importers:
       '@types/js-yaml': ^4.0.5
       '@types/lodash': ^4.14.181
       '@types/node': ^14
+      '@types/qs': ^6.9.7
       '@types/uuid': ^8.3.4
       '@vendia/serverless-express': ^4.5.4
       aws-cdk: ^2.12.0
@@ -286,6 +287,7 @@ importers:
       '@types/js-yaml': 4.0.5
       '@types/lodash': 4.14.182
       '@types/node': 14.18.20
+      '@types/qs': 6.9.7
       '@types/uuid': 8.3.4
       aws-cdk: 2.26.0
       aws-cdk-lib: 2.29.1_constructs@10.1.25
@@ -3754,7 +3756,7 @@ packages:
       events: 3.3.0
       jws: 3.2.2
       msal: 1.4.16
-      qs: 6.10.3
+      qs: 6.11.0
       tslib: 1.14.1
       uuid: 3.4.0
     transitivePeerDependencies:
@@ -8958,6 +8960,11 @@ packages:
     engines: {node: '>=0.10'}
     dev: true
 
+  /decode-uri-component/0.2.2:
+    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
+    engines: {node: '>=0.10'}
+    dev: true
+
   /decompress-response/6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -13892,6 +13899,13 @@ packages:
     dependencies:
       side-channel: 1.0.4
 
+  /qs/6.11.0:
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: false
+
   /qs/6.5.3:
     resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
     engines: {node: '>=0.6'}
@@ -14748,7 +14762,7 @@ packages:
     deprecated: See https://github.com/lydell/source-map-resolve#deprecated
     dependencies:
       atob: 2.1.2
-      decode-uri-component: 0.2.0
+      decode-uri-component: 0.2.2
       resolve-url: 0.2.1
       source-map-url: 0.4.1
       urix: 0.1.0

--- a/solutions/swb-app/src/environmentTypeRoutes.ts
+++ b/solutions/swb-app/src/environmentTypeRoutes.ts
@@ -4,7 +4,6 @@
  */
 
 import {
-  CreateEnvironmentTypeSchema,
   EnvironmentTypeService,
   isEnvironmentTypeStatus,
   ENVIRONMENT_TYPE_STATUS,
@@ -19,25 +18,6 @@ import { wrapAsync } from './errorHandlers';
 import { processValidatorResult, validateAndParse } from './validatorHelper';
 
 export function setUpEnvTypeRoutes(router: Router, environmentTypeService: EnvironmentTypeService): void {
-  // Create envType
-  router.post(
-    '/environmentTypes',
-    wrapAsync(async (req: Request, res: Response) => {
-      processValidatorResult(validate(req.body, CreateEnvironmentTypeSchema));
-      const { status } = req.body;
-
-      if (!isEnvironmentTypeStatus(status)) {
-        throw Boom.badRequest(
-          `Status provided is: ${status}. Status needs to be one of these values: ${ENVIRONMENT_TYPE_STATUS}`
-        );
-      }
-      const envType = await environmentTypeService.createNewEnvironmentType({
-        ...req.body
-      });
-      res.status(201).send(envType);
-    })
-  );
-
   // Get envType
   router.get(
     '/environmentTypes/:id',

--- a/solutions/swb-app/src/staticRouteConfig.ts
+++ b/solutions/swb-app/src/staticRouteConfig.ts
@@ -149,12 +149,6 @@ export const routesMap: RoutesMap = {
         action: 'READ',
         subject: 'EnvironmentType'
       }
-    ],
-    POST: [
-      {
-        action: 'CREATE',
-        subject: 'EnvironmentType'
-      }
     ]
   },
   [`/environmentTypes/${envTypeIdRegExpString}`]: {

--- a/solutions/swb-reference/SWBv2.postman_collection.json
+++ b/solutions/swb-reference/SWBv2.postman_collection.json
@@ -631,39 +631,6 @@
       "name": "envType",
       "item": [
         {
-          "name": "Create envType",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Cookie",
-                "value": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}}",
-                "type": "text"
-              },
-              {
-                "key": "csrf-token",
-                "value": "{{CSRF_TOKEN}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"productId\": \"prod-abcd1234\",\n    \"provisioningArtifactId\": \"pa-abcd1234\",\n    \"description\": \"An Amazon SageMaker Jupyter Notebook\",\n    \"name\": \"Jupyter Notebook\",\n    \"type\": \"sagemakerNotebook\",\n    \"params\": {\n       \"InstanceType\": {\n        \"Description\": \"EC2 instance type to launch\",\n        \"Default\": \"ml.t3.xlarge\",\n        \"AllowedValues\": [],\n         \"Type\": \"String\"\n         }\n       },\n    \"status\": \"NOT_APPROVED\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{API_URL}}/environmentTypes",
-              "host": ["{{API_URL}}"],
-              "path": ["environmentTypes"]
-            }
-          },
-          "response": []
-        },
-        {
           "name": "Update envType",
           "request": {
             "method": "PATCH",

--- a/solutions/swb-reference/integration-tests/support/clientSession.ts
+++ b/solutions/swb-reference/integration-tests/support/clientSession.ts
@@ -5,6 +5,7 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
 import Csrf from 'csrf';
 import _ from 'lodash';
+import Qs from 'qs';
 import { getResources, Resources } from './resources';
 import Setup from './setup';
 import HttpError from './utils/HttpError';
@@ -43,6 +44,14 @@ export default class ClientSession {
       baseURL: this._settings.get('apiUrlOutput'),
       timeout: 30000, // 30 seconds to mimic API gateway timeout
       headers
+    });
+
+    this._axiosInstance.interceptors.request.use((config) => {
+      config.paramsSerializer = (params) => {
+        return Qs.stringify(params);
+      };
+
+      return config;
     });
 
     // Convert AxiosError to HttpError for easier error checking in tests

--- a/solutions/swb-reference/integration-tests/support/complex/environmentTypeHelper.ts
+++ b/solutions/swb-reference/integration-tests/support/complex/environmentTypeHelper.ts
@@ -1,0 +1,37 @@
+import { AwsService } from '@aws/workbench-core-base';
+import { EnvironmentTypeService, EnvironmentType } from '@aws/workbench-core-environments';
+import Setup from '../setup';
+import RandomTextGenerator from '../utils/randomTextGenerator';
+import Settings from '../utils/settings';
+
+export class EnvironmentTypeHelper {
+  private _awsSdk: AwsService;
+  private _settings: Settings;
+  private _environmentTypeService: EnvironmentTypeService;
+  public constructor() {
+    const setup = new Setup();
+    this._awsSdk = setup.getMainAwsClient();
+    this._settings = setup.getSettings();
+    this._environmentTypeService = new EnvironmentTypeService({ TABLE_NAME: setup.getStackName() });
+  }
+
+  public async createEnvironmentType(
+    productId: string,
+    provisioningArtifactId: string
+  ): Promise<EnvironmentType> {
+    const randomTextGenerator = new RandomTextGenerator(this._settings.get('runId'));
+    return this._environmentTypeService.createNewEnvironmentType({
+      description: randomTextGenerator.getFakeText('fakeDescription'),
+      name: randomTextGenerator.getFakeText('fakeName'),
+      params: {},
+      productId,
+      provisioningArtifactId,
+      status: 'NOT_APPROVED',
+      type: randomTextGenerator.getFakeText('fakeType')
+    });
+  }
+
+  public async deleteEnvironmentType(envTypeId: string): Promise<void> {
+    await this._awsSdk.helpers.ddb.delete({ pk: `ET#${envTypeId}`, sk: `ET#${envTypeId}` }).execute();
+  }
+}

--- a/solutions/swb-reference/integration-tests/support/resources.ts
+++ b/solutions/swb-reference/integration-tests/support/resources.ts
@@ -7,13 +7,17 @@ import Accounts from './resources/accounts/accounts';
 import CostCenters from './resources/costCenters/costCenters';
 import Datasets from './resources/datasets/datasets';
 import Environments from './resources/environments/environments';
+import EnvironmentTypeConfigs from './resources/environmentTypeConfigs/environmentTypeConfigs';
+import EnvironmentTypes from './resources/environmentTypes/environmentTypes';
 
 function getResources(clientSession: ClientSession): Resources {
   return {
     environments: new Environments(clientSession),
     datasets: new Datasets(clientSession),
     accounts: new Accounts(clientSession),
-    costCenters: new CostCenters(clientSession)
+    costCenters: new CostCenters(clientSession),
+    environmentTypes: new EnvironmentTypes(clientSession),
+    environmentTypeConfigs: new EnvironmentTypeConfigs(clientSession)
   };
 }
 
@@ -22,6 +26,8 @@ interface Resources {
   environments: Environments;
   datasets: Datasets;
   costCenters: CostCenters;
+  environmentTypes: EnvironmentTypes;
+  environmentTypeConfigs: EnvironmentTypeConfigs;
 }
 
 export { getResources, Resources };

--- a/solutions/swb-reference/integration-tests/support/resources/environmentTypeConfigs/environmentTypeConfig.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/environmentTypeConfigs/environmentTypeConfig.ts
@@ -1,0 +1,25 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../clientSession';
+import { DEFLAKE_DELAY_IN_MILLISECONDS } from '../../utils/constants';
+import { sleep } from '../../utils/utilities';
+import Resource from '../base/resource';
+
+export default class EnvironmentTypeConfig extends Resource {
+  private _envTypeId: string;
+  public constructor(id: string, clientSession: ClientSession, parentApi: string, envTypeId: string) {
+    const prefix = `environmentTypes/${envTypeId}/${parentApi}`;
+    super(clientSession, 'environmentTypeConfig', id, prefix);
+    this._envTypeId = envTypeId;
+  }
+
+  protected async cleanup(): Promise<void> {
+    const defAdminSession = await this._setup.getDefaultAdminSession();
+    await sleep(DEFLAKE_DELAY_IN_MILLISECONDS); //Avoid throttling when terminating multiple environment type configs
+    await defAdminSession.resources.environmentTypeConfigs
+      .environmentTypeConfig(this._id, this._envTypeId)
+      .delete();
+  }
+}

--- a/solutions/swb-reference/integration-tests/support/resources/environmentTypeConfigs/environmentTypeConfigs.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/environmentTypeConfigs/environmentTypeConfigs.ts
@@ -1,0 +1,39 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../clientSession';
+import RandomTextGenerator from '../../utils/randomTextGenerator';
+import CollectionResource from '../base/collectionResource';
+import EnvironmentTypeConfig from './environmentTypeConfig';
+
+export default class EnvironmentTypeConfigs extends CollectionResource {
+  public constructor(clientSession: ClientSession) {
+    super(clientSession, 'environmentTypeConfigs', 'environmentTypeConfig', 'environmentTypes/:parentId/');
+    this._api = 'configurations';
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public environmentTypeConfig(id: string, envTypeId: string): EnvironmentTypeConfig {
+    return new EnvironmentTypeConfig(id, this._clientSession, this._api, envTypeId);
+  }
+
+  protected _buildDefaults(resource: ETCCreateRequest): ETCCreateRequest {
+    const randomTextGenerator = new RandomTextGenerator(this._settings.get('runId'));
+    return {
+      description: resource.description ?? randomTextGenerator.getFakeText('fakeDescription'),
+      name: resource.name ?? randomTextGenerator.getFakeText('fakeName'),
+      type: resource.type ?? randomTextGenerator.getFakeText('fakeType'),
+      params: resource.params ?? [],
+      estimatedCost: resource.name ?? randomTextGenerator.getFakeText('fakeEstimatedCost')
+    };
+  }
+}
+
+interface ETCCreateRequest {
+  description: string;
+  name: string;
+  type: string;
+  estimatedCost: string;
+  params: string[];
+}

--- a/solutions/swb-reference/integration-tests/support/resources/environmentTypes/environmentType.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/environmentTypes/environmentType.ts
@@ -1,0 +1,21 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../clientSession';
+import { EnvironmentTypeHelper } from '../../complex/environmentTypeHelper';
+import { DEFLAKE_DELAY_IN_MILLISECONDS } from '../../utils/constants';
+import { sleep } from '../../utils/utilities';
+import Resource from '../base/resource';
+
+export default class EnvironmentType extends Resource {
+  public constructor(id: string, clientSession: ClientSession, parentApi: string) {
+    super(clientSession, 'environmentType', id, parentApi);
+  }
+
+  protected async cleanup(): Promise<void> {
+    await sleep(DEFLAKE_DELAY_IN_MILLISECONDS); //Avoid throttling when terminating multiple environment types
+    const envTypeHelper = new EnvironmentTypeHelper();
+    await envTypeHelper.deleteEnvironmentType(this._id);
+  }
+}

--- a/solutions/swb-reference/integration-tests/support/resources/environmentTypes/environmentTypes.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/environmentTypes/environmentTypes.ts
@@ -1,0 +1,19 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../clientSession';
+import CollectionResource from '../base/collectionResource';
+import EnvironmentType from './environmentType';
+
+export default class EnvironmentTypes extends CollectionResource {
+  public constructor(clientSession: ClientSession) {
+    super(clientSession, 'environmentTypes', 'environmentType');
+    this._api = 'environmentTypes';
+  }
+
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  public environmentType(id: string): EnvironmentType {
+    return new EnvironmentType(id, this._clientSession, this._api);
+  }
+}

--- a/solutions/swb-reference/integration-tests/support/utils/regExpressions.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/regExpressions.ts
@@ -7,3 +7,5 @@ import { resourceTypeToKey, uuidWithLowercasePrefixRegExp } from '@aws/workbench
 export const envUuidRegExp: RegExp = uuidWithLowercasePrefixRegExp(resourceTypeToKey.environment);
 
 export const dsUuidRegExp: RegExp = uuidWithLowercasePrefixRegExp(resourceTypeToKey.dataset);
+
+export const envTypeConfigRegExp: RegExp = uuidWithLowercasePrefixRegExp(resourceTypeToKey.envTypeConfig);

--- a/solutions/swb-reference/integration-tests/tests/isolated/environmentTypeConfigs/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environmentTypeConfigs/create.test.ts
@@ -1,0 +1,166 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../../support/clientSession';
+import Setup from '../../../support/setup';
+import HttpError from '../../../support/utils/HttpError';
+import { checkHttpError } from '../../../support/utils/utilities';
+
+describe('create environment type configs', () => {
+  const setup: Setup = new Setup();
+  let adminSession: ClientSession;
+  const envTypeId = setup.getSettings().get('envTypeId');
+
+  beforeEach(() => {
+    expect.hasAssertions();
+  });
+
+  beforeAll(async () => {
+    adminSession = await setup.getDefaultAdminSession();
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  test('fails when trying to create without name', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs.create(
+        {
+          type: 'typeTest',
+          description: 'description',
+          params: []
+        },
+        false,
+        envTypeId
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'name: Required'
+        })
+      );
+    }
+  });
+
+  test('fails when trying to create without type', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs.create(
+        {
+          name: 'name',
+          description: 'description',
+          params: []
+        },
+        false,
+        envTypeId
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'type: Required'
+        })
+      );
+    }
+  });
+
+  test('fails when trying to create without params', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs.create(
+        {
+          name: 'name',
+          description: 'description',
+          type: 'type'
+        },
+        false,
+        envTypeId
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'params: Required'
+        })
+      );
+    }
+  });
+
+  test('fails when trying to create with invalid prop', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs.create(
+        {
+          type: 'typeTest',
+          description: 'description',
+          name: 'name',
+          invalidProp: 'invalidValue',
+          params: []
+        },
+        false,
+        envTypeId
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: ": Unrecognized key(s) in object: 'invalidProp'"
+        })
+      );
+    }
+  });
+
+  test('fails when trying to create with invalid environment Type Id', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs.create(
+        {
+          type: 'typeTest',
+          description: 'description',
+          name: 'name',
+          params: []
+        },
+        false,
+        'et-prod-1234567890124,pa-1234567890124'
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: `Could not create environment type config because environment type et-prod-1234567890124,pa-1234567890124 does not exist`
+        })
+      );
+    }
+  });
+
+  test('fails when trying to create with invalid environment Type id format', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs.create(
+        {
+          type: 'typeTest',
+          description: 'description',
+          name: 'name',
+          params: []
+        },
+        false,
+        'wrong-foramt-env-type-id'
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(403, {
+          error: 'User is not authorized'
+        })
+      );
+    }
+  });
+});

--- a/solutions/swb-reference/integration-tests/tests/isolated/environmentTypeConfigs/list.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environmentTypeConfigs/list.test.ts
@@ -1,0 +1,44 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../../support/clientSession';
+import Setup from '../../../support/setup';
+import HttpError from '../../../support/utils/HttpError';
+import { checkHttpError } from '../../../support/utils/utilities';
+
+describe('list environment type configs', () => {
+  const setup: Setup = new Setup();
+  let adminSession: ClientSession;
+  const envTypeId = setup.getSettings().get('envTypeId');
+
+  beforeEach(() => {
+    expect.hasAssertions();
+  });
+
+  beforeAll(async () => {
+    adminSession = await setup.getDefaultAdminSession();
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  test('list environments type configs when filter and sorting by name', async () => {
+    const { data: response } = await adminSession.resources.environmentTypeConfigs.get({}, envTypeId);
+    expect(Array.isArray(response.data)).toBe(true);
+  });
+
+  test('list environments type configs fails when using invalid format envType Id', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs.get({}, 'invalid-envType-id');
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(403, {
+          error: 'User is not authorized'
+        })
+      );
+    }
+  });
+});

--- a/solutions/swb-reference/integration-tests/tests/isolated/environmentTypeConfigs/update.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environmentTypeConfigs/update.test.ts
@@ -1,0 +1,91 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../../support/clientSession';
+import Setup from '../../../support/setup';
+import HttpError from '../../../support/utils/HttpError';
+import { checkHttpError } from '../../../support/utils/utilities';
+
+describe('update environment type configs', () => {
+  const setup: Setup = new Setup();
+  let adminSession: ClientSession;
+  const envTypeId = setup.getSettings().get('envTypeId');
+  const envTypeConfigId = setup.getSettings().get('envTypeConfigId');
+
+  beforeEach(() => {
+    expect.hasAssertions();
+  });
+
+  beforeAll(async () => {
+    adminSession = await setup.getDefaultAdminSession();
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  test('fails when trying to update invalid prop', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs
+        .environmentTypeConfig(envTypeConfigId, envTypeId)
+        .update(
+          {
+            invalidProp: 'invalidValue'
+          },
+          true
+        );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: ": Unrecognized key(s) in object: 'invalidProp'"
+        })
+      );
+    }
+  });
+
+  test('fails when trying to update invalid environment Type Config', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs
+        .environmentTypeConfig('etc-12345678-1234-1234-1234-123456789012', envTypeId)
+        .update(
+          {
+            description: 'new Description'
+          },
+          true
+        );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(404, {
+          statusCode: 404,
+          error: 'Not Found',
+          message: `Could not find envType ${envTypeId} with envTypeConfig etc-12345678-1234-1234-1234-123456789012 to update`
+        })
+      );
+    }
+  });
+
+  test('fails when trying to update invalid environment Type id format', async () => {
+    try {
+      await adminSession.resources.environmentTypeConfigs
+        .environmentTypeConfig('wrong-format-id', envTypeId)
+        .update(
+          {
+            description: 'new Description'
+          },
+          true
+        );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(403, {
+          error: 'User is not authorized'
+        })
+      );
+    }
+  });
+});

--- a/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/list.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/list.test.ts
@@ -1,0 +1,90 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../../support/clientSession';
+import Setup from '../../../support/setup';
+import HttpError from '../../../support/utils/HttpError';
+import { checkHttpError } from '../../../support/utils/utilities';
+
+describe('list environment types', () => {
+  const setup: Setup = new Setup();
+  let adminSession: ClientSession;
+
+  beforeEach(() => {
+    expect.hasAssertions();
+  });
+
+  beforeAll(async () => {
+    adminSession = await setup.getDefaultAdminSession();
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  test('list environments types when filter and sorting by name', async () => {
+    const { data: response } = await adminSession.resources.environmentTypes.get({
+      filter: {
+        name: { begins: 'Sage' }
+      },
+      sort: {
+        name: 'desc'
+      }
+    });
+    expect(Array.isArray(response.data)).toBe(true);
+  });
+
+  test('list environments types when filter and sorting by status', async () => {
+    const { data: response } = await adminSession.resources.environmentTypes.get({
+      filter: {
+        status: { begins: 'NOT' }
+      },
+      sort: {
+        status: 'desc'
+      }
+    });
+    expect(Array.isArray(response.data)).toBe(true);
+  });
+
+  test('list environments types fails when filter by invalid prop', async () => {
+    try {
+      await adminSession.resources.environmentTypes.get({
+        filter: {
+          someProperty: { begins: 'NOT' }
+        }
+      });
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: "filter: Unrecognized key(s) in object: 'someProperty'"
+        })
+      );
+    }
+  });
+
+  test('list environments types fails when filter and sorting different props', async () => {
+    try {
+      await adminSession.resources.environmentTypes.get({
+        filter: {
+          status: { begins: 'NOT' }
+        },
+        sort: {
+          name: 'desc'
+        }
+      });
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: 'Cannot apply a filter and sort to different properties at the same time'
+        })
+      );
+    }
+  });
+});

--- a/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/update.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/update.test.ts
@@ -1,0 +1,84 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../../support/clientSession';
+import Setup from '../../../support/setup';
+import HttpError from '../../../support/utils/HttpError';
+import { checkHttpError } from '../../../support/utils/utilities';
+
+describe('update environment types', () => {
+  const setup: Setup = new Setup();
+  let adminSession: ClientSession;
+  const testEnvTypeId = 'et-prod-1234567890124,pa-1234567890124';
+  beforeEach(() => {
+    expect.hasAssertions();
+  });
+
+  beforeAll(async () => {
+    adminSession = await setup.getDefaultAdminSession();
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  test('fails when trying to update invalid prop', async () => {
+    try {
+      await adminSession.resources.environmentTypes.environmentType(testEnvTypeId).update(
+        {
+          invalidProp: 'invalidValue'
+        },
+        true
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          statusCode: 400,
+          error: 'Bad Request',
+          message: "is not allowed to have the additional property 'invalidProp'"
+        })
+      );
+    }
+  });
+
+  test('fails when trying to update invalid environment Type', async () => {
+    try {
+      await adminSession.resources.environmentTypes.environmentType(testEnvTypeId).update(
+        {
+          name: 'new Name',
+          status: 'APPROVED'
+        },
+        true
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(404, {
+          statusCode: 404,
+          error: 'Not Found',
+          message: `Could not find environment type ${testEnvTypeId} to update`
+        })
+      );
+    }
+  });
+
+  test('fails when trying to update invalid environment Type id format', async () => {
+    try {
+      await adminSession.resources.environmentTypes.environmentType('wrong-format-id').update(
+        {
+          name: 'new Name'
+        },
+        true
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(403, {
+          error: 'User is not authorized'
+        })
+      );
+    }
+  });
+});

--- a/solutions/swb-reference/integration-tests/tests/multiStep/et-etc.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/et-etc.test.ts
@@ -1,0 +1,89 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import { resourceTypeToKey } from '@aws/workbench-core-base';
+import ClientSession from '../../support/clientSession';
+import { EnvironmentTypeHelper } from '../../support/complex/environmentTypeHelper';
+import Setup from '../../support/setup';
+import { envTypeConfigRegExp } from '../../support/utils/regExpressions';
+
+describe('multiStep environment type and environment type config test', () => {
+  const setup: Setup = new Setup();
+  let adminSession: ClientSession;
+  const envTypeHandler = new EnvironmentTypeHelper();
+  beforeAll(async () => {
+    adminSession = await setup.getDefaultAdminSession();
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  test('create Environment Type', async () => {
+    //Create Environment A
+    console.log('Creating Environment Type');
+    const envType = await envTypeHandler.createEnvironmentType('prod-1234567890123', 'pa-1234567890123');
+    const expectedId = `${resourceTypeToKey.envType.toLowerCase()}-prod-1234567890123,pa-1234567890123`;
+    expect(envType).toMatchObject({
+      id: expectedId,
+      status: 'NOT_APPROVED'
+    });
+
+    //Approve Environment Type
+    console.log('Approve Environment Type');
+    await adminSession.resources.environmentTypes.environmentType(envType.id).update(
+      {
+        status: 'APPROVED'
+      },
+      true
+    );
+    const { data: approvedEnvType } = await adminSession.resources.environmentTypes
+      .environmentType(envType.id)
+      .get();
+    expect(approvedEnvType).toMatchObject({
+      status: 'APPROVED'
+    });
+
+    //Create Environment Type Config
+    console.log('Creating Environment Type Config');
+    const { data: envTypeConfig } = await adminSession.resources.environmentTypeConfigs.create(
+      {},
+      true,
+      envType.id
+    );
+    expect(envTypeConfig).toMatchObject({
+      id: expect.stringMatching(envTypeConfigRegExp)
+    });
+
+    //Update Environment Type Config
+    console.log('Update Environment Type Config');
+    await adminSession.resources.environmentTypeConfigs
+      .environmentTypeConfig(envTypeConfig.id, envType.id)
+      .update(
+        {
+          description: 'new Description',
+          estimatedCost: 'new Estimated Cost'
+        },
+        true
+      );
+    const { data: updatedEnvTypeConfig } = await adminSession.resources.environmentTypeConfigs
+      .environmentTypeConfig(envTypeConfig.id, envType.id)
+      .get();
+    expect(updatedEnvTypeConfig).toMatchObject({
+      description: 'new Description',
+      estimatedCost: 'new Estimated Cost'
+    });
+    //Delete Environment Type Config
+    console.log('Delete Environment Type Config');
+    await expect(
+      adminSession.resources.environmentTypeConfigs
+        .environmentTypeConfig(envTypeConfig.id, envType.id)
+        .delete()
+    ).resolves;
+
+    //Delete Environment Type
+    console.log('Delete Environment Type');
+    await expect(envTypeHandler.deleteEnvironmentType(envType.id)).resolves;
+  });
+});

--- a/solutions/swb-reference/package.json
+++ b/solutions/swb-reference/package.json
@@ -81,6 +81,7 @@
     "@types/js-yaml": "^4.0.5",
     "@types/lodash": "^4.14.181",
     "@types/node": "^14",
+    "@types/qs": "^6.9.7",
     "@types/uuid": "^8.3.4",
     "aws-cdk": "^2.12.0",
     "aws-cdk-lib": "^2.29.1",

--- a/workbench-core/environments/src/index.ts
+++ b/workbench-core/environments/src/index.ts
@@ -31,6 +31,7 @@ import {
   UpdateEnvironmentTypeConfigRequest,
   UpdateEnvironmentTypeConfigRequestParser
 } from './models/environmentTypeConfigs/updateEnvironmentTypeConfigsRequest';
+import { EnvironmentType } from './models/environmentTypes/environmentType';
 import {
   ListEnvironmentTypesRequest,
   ListEnvironmentTypesRequestParser
@@ -62,6 +63,7 @@ export {
   EnvironmentTypeService,
   Environment,
   EnvironmentTypeStatus,
+  EnvironmentType,
   isEnvironmentTypeStatus,
   ENVIRONMENT_TYPE_STATUS,
   EnvironmentTypeConfigService,


### PR DESCRIPTION
Issue #, if available:
GALI-1846
Description of changes:
-Add Integration tests for ET and ETC
-Delete create API for ET (creation happens automatically with handler)

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.