### PR TITLE
chore: update github's hostingAccountHandlerRoleArn value for integration tests

### DIFF
--- a/solutions/swb-reference/integration-tests/config/testEnv.yaml
+++ b/solutions/swb-reference/integration-tests/config/testEnv.yaml
@@ -20,4 +20,4 @@ defaultHostingAccountId: 'acc-827e79f0-f007-4b6a-9640-937abbb98e0d'
 
 ## Hosting account used for Account Creation tests
 hostAwsAccountIdParamStorePath: '/swb/testEnv/accountsTest/awsAccountId'
-hostingAccountHandlerRoleArn: 'arn:aws:iam::748244046650:role/swb-dev-va-hosting-account-role'
+hostingAccountHandlerRoleArnParamStorePath: '/swb/testEnv/accountsTest/hostingAccountHandlerRoleArn'

--- a/solutions/swb-reference/integration-tests/config/testEnv.yaml
+++ b/solutions/swb-reference/integration-tests/config/testEnv.yaml
@@ -20,3 +20,4 @@ defaultHostingAccountId: 'acc-827e79f0-f007-4b6a-9640-937abbb98e0d'
 
 ## Hosting account used for Account Creation tests
 hostAwsAccountIdParamStorePath: '/swb/testEnv/accountsTest/awsAccountId'
+hostingAccountHandlerRoleArn: 'arn:aws:iam::748244046650:role/swb-dev-va-hosting-account-role'

--- a/solutions/swb-reference/integration-tests/support/setup.ts
+++ b/solutions/swb-reference/integration-tests/support/setup.ts
@@ -47,6 +47,11 @@ export default class Setup {
       );
       this._settings.set('hostAwsAccountId', hostAwsAccountId);
 
+      const hostingAccountHandlerRoleArn = await secretsService.getSecret(
+        this._settings.get('hostingAccountHandlerRoleArnParamStorePath')
+      );
+      this._settings.set('hostingAccountHandlerRoleArn', hostingAccountHandlerRoleArn);
+
       const cognitoTokenService = new CognitoTokenService(awsRegion, secretsService);
       const { accessToken } = await cognitoTokenService.generateCognitoToken({
         userPoolId,

--- a/solutions/swb-reference/integration-tests/support/utils/settings.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/settings.ts
@@ -47,6 +47,7 @@ interface Setting {
   hostAwsAccountIdParamStorePath: string;
   envMgmtRoleArn: string;
   hostingAccountHandlerRoleArn: string;
+  hostingAccountHandlerRoleArnParamStorePath: string;
   encryptionKeyArn: string;
 
   // Derived

--- a/workbench-core/example/infrastructure/integration-tests/support/setup.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/setup.ts
@@ -42,10 +42,6 @@ export default class Setup {
       const awsRegion = this._settings.get('AwsRegion');
 
       const secretsService = new SecretsService(new AwsService({ region: awsRegion }).clients.ssm);
-      const hostAwsAccountId = await secretsService.getSecret(
-        this._settings.get('hostAwsAccountIdParamStorePath')
-      );
-      this._settings.set('hostAwsAccountId', hostAwsAccountId);
 
       const cognitoTokenService = new CognitoTokenService(awsRegion, secretsService);
       const { accessToken } = await cognitoTokenService.generateCognitoToken({


### PR DESCRIPTION
When merging in the `awsAccount` feature branch, I failed to notice that there was not a default value set for `hostingAccountHandlerRoleArn` in the `testEnv.yaml` file which gets used when running integration tests after merge. I've added a value, so tests should now run.

