### PR TITLE
feat(wbcgroupmanagementplugin.ts): implementing addUserToGroup

### DIFF
--- a/workbench-core/authorization/src/dynamicAuthorization/wbcGroupManagementPlugin.test.ts
+++ b/workbench-core/authorization/src/dynamicAuthorization/wbcGroupManagementPlugin.test.ts
@@ -1,0 +1,63 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { UserManagementService, UserManagementPlugin } from '@aws/workbench-core-user-management';
+import { AuthenticatedUser } from '../authenticatedUser';
+import { WBCGroupManagemntPlugin } from './wbcGroupManagementPlugin';
+
+describe('WBCGroupManagemntPlugin', () => {
+  const mockUser: AuthenticatedUser = {
+    id: 'sampleId',
+    roles: []
+  };
+
+  const mockUserManagementPlugin: UserManagementPlugin = {
+    getUser: jest.fn(),
+    createUser: jest.fn(),
+    updateUser: jest.fn(),
+    deleteUser: jest.fn(),
+    activateUser: jest.fn(),
+    deactivateUser: jest.fn(),
+    listUsers: jest.fn(),
+    listUsersForRole: jest.fn(),
+    listRoles: jest.fn(),
+    addUserToRole: jest.fn(),
+    removeUserFromRole: jest.fn(),
+    createRole: jest.fn(),
+    deleteRole: jest.fn()
+  };
+
+  afterEach(jest.resetAllMocks);
+
+  test('Response from addUserToGroup has added equal to true on succesfull call', async () => {
+    const userManagementService: UserManagementService = new UserManagementService(mockUserManagementPlugin);
+    const wBCGroupManagemntPlugin = new WBCGroupManagemntPlugin(userManagementService);
+
+    const { added } = await wBCGroupManagemntPlugin.addUserToGroup({
+      groupId: 'groupId',
+      userId: 'userId',
+      authenticatedUser: mockUser
+    });
+
+    expect(mockUserManagementPlugin.addUserToRole).toBeCalledWith('groupId', 'userId');
+    expect(added).toBeTruthy();
+  });
+
+  test('Response from addUserToGroup has added equal to false when UserManagementService throws exception', async () => {
+    mockUserManagementPlugin.addUserToRole = jest.fn().mockRejectedValue(new Error('Test error'));
+    const userManagementService: UserManagementService = new UserManagementService(mockUserManagementPlugin);
+
+    const wBCGroupManagemntPlugin = new WBCGroupManagemntPlugin(userManagementService);
+
+    const { added } = await wBCGroupManagemntPlugin.addUserToGroup({
+      groupId: 'groupId',
+      userId: 'userId',
+      authenticatedUser: mockUser
+    });
+
+    expect(mockUserManagementPlugin.addUserToRole).toBeCalledWith('groupId', 'userId');
+    expect(added).toBeFalsy();
+  });
+});

--- a/workbench-core/authorization/src/dynamicAuthorization/wbcGroupManagementPlugin.ts
+++ b/workbench-core/authorization/src/dynamicAuthorization/wbcGroupManagementPlugin.ts
@@ -39,8 +39,16 @@ export class WBCGroupManagemntPlugin implements GroupManagementPlugin {
   public getGroupUsers(request: GetGroupUsersRequest): Promise<GetGroupUsersResponse> {
     throw new Error('Method not implemented.');
   }
-  public addUserToGroup(request: AddUserToGroupRequest): Promise<AddUserToGroupResponse> {
-    throw new Error('Method not implemented.');
+  public async addUserToGroup(request: AddUserToGroupRequest): Promise<AddUserToGroupResponse> {
+    const { groupId, userId } = request;
+
+    try {
+      await this._userManagementService.addUserToRole(userId, groupId);
+      return { added: true };
+    } catch (e) {
+      // ToDo: Add logging
+      return { added: false };
+    }
   }
   public isUserAssignedToGroup(
     request: IsUserAssignedToGroupRequest


### PR DESCRIPTION
Issue #, if available: MAFoundation-517

Description of changes:

This PR adds implementation of addUserGroup method in Workbench Core User Management Service

*Note:* Requires https://github.com/aws-solutions/solution-spark-on-aws/pull/700 to be merged

Checklist:

* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.