### PR TITLE
feat: [GALI-2125] add fields to data set creation

### DIFF
--- a/common/changes/@aws/swb-app/atmikev-GALI-2125_AddFieldsToDataSetCreation_2022-12-21-16-55.json
+++ b/common/changes/@aws/swb-app/atmikev-GALI-2125_AddFieldsToDataSetCreation_2022-12-21-16-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "adding `type` and `owner` to dataset creation API",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/common/changes/@aws/workbench-core-base/atmikev-GALI-2125_AddFieldsToDataSetCreation_2022-12-21-16-55.json
+++ b/common/changes/@aws/workbench-core-base/atmikev-GALI-2125_AddFieldsToDataSetCreation_2022-12-21-16-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "adding `type` and `owner` to dataset creation API",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/common/changes/@aws/workbench-core-datasets/atmikev-GALI-2125_AddFieldsToDataSetCreation_2022-12-21-00-43.json
+++ b/common/changes/@aws/workbench-core-datasets/atmikev-GALI-2125_AddFieldsToDataSetCreation_2022-12-21-00-43.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-datasets",
+      "comment": "adding 'owner' and 'type' to dataset creation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-datasets"
+}

--- a/solutions/swb-app/src/dataSetRoutes.ts
+++ b/solutions/swb-app/src/dataSetRoutes.ts
@@ -19,7 +19,7 @@ export function setUpDSRoutes(router: Router, dataSetService: DataSetPlugin): vo
     wrapAsync(async (req: Request, res: Response) => {
       processValidatorResult(validate(req.body, CreateDataSetSchema));
       const dataSet = await dataSetService.provisionDataSet({
-        name: req.body.datasetName,
+        name: req.body.name,
         storageName: req.body.storageName,
         path: req.body.path,
         awsAccountId: req.body.awsAccountId,
@@ -39,7 +39,7 @@ export function setUpDSRoutes(router: Router, dataSetService: DataSetPlugin): vo
     wrapAsync(async (req: Request, res: Response) => {
       processValidatorResult(validate(req.body, CreateDataSetSchema));
       const dataSet = await dataSetService.importDataSet({
-        name: req.body.datasetName,
+        name: req.body.name,
         storageName: req.body.storageName,
         path: req.body.path,
         awsAccountId: req.body.awsAccountId,

--- a/solutions/swb-app/src/dataSetRoutes.ts
+++ b/solutions/swb-app/src/dataSetRoutes.ts
@@ -24,7 +24,9 @@ export function setUpDSRoutes(router: Router, dataSetService: DataSetPlugin): vo
         path: req.body.path,
         awsAccountId: req.body.awsAccountId,
         region: req.body.region,
-        storageProvider: dataSetService.storagePlugin
+        storageProvider: dataSetService.storagePlugin,
+        owner: req.body.owner,
+        type: req.body.type
       });
 
       res.status(201).send(dataSet);
@@ -42,7 +44,9 @@ export function setUpDSRoutes(router: Router, dataSetService: DataSetPlugin): vo
         path: req.body.path,
         awsAccountId: req.body.awsAccountId,
         region: req.body.region,
-        storageProvider: dataSetService.storagePlugin
+        storageProvider: dataSetService.storagePlugin,
+        owner: req.body.owner,
+        type: req.body.type
       });
       res.status(201).send(dataSet);
     })

--- a/solutions/swb-reference/SWBv2.postman_collection.json
+++ b/solutions/swb-reference/SWBv2.postman_collection.json
@@ -242,7 +242,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"datasetName\": \"testDs\",\n    \"storageName\": \"datasetBucketNameInMainAccount\",\n    \"path\": \"folderName\",\n    \"awsAccountId\": \"mainAccountId\"\n}",
+              "raw": "{\n    \"datasetName\": \"testDs\",\n    \"storageName\": \"datasetBucketNameInMainAccount\",\n    \"path\": \"folderName\",\n    \"awsAccountId\": \"mainAccountId\"\n,\n    \"type\": \"internal\"\n,\n    \"owner\": \"proj-123#PA\"\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/solutions/swb-reference/integration-tests/support/resources/datasets/datasets.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/datasets/datasets.ts
@@ -30,7 +30,9 @@ export default class Datasets extends CollectionResource {
       path: resource.path ?? dataSetName,
       storageName: resource.storageName,
       awsAccountId: resource.awsAccountId,
-      region: resource.region
+      region: resource.region,
+      owner: resource.owner,
+      type: resource.type
     };
   }
 }
@@ -41,4 +43,6 @@ interface DataSetCreateRequest {
   path: string;
   awsAccountId: string;
   region: string;
+  owner: string;
+  type: string;
 }

--- a/solutions/swb-reference/integration-tests/support/resources/datasets/datasets.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/datasets/datasets.ts
@@ -26,7 +26,7 @@ export default class Datasets extends CollectionResource {
     const randomTextGenerator = new RandomTextGenerator(this._settings.get('runId'));
     const dataSetName = randomTextGenerator.getFakeText('test-DS');
     return {
-      datasetName: resource.datasetName ?? dataSetName,
+      name: resource.name ?? dataSetName,
       path: resource.path ?? dataSetName,
       storageName: resource.storageName,
       awsAccountId: resource.awsAccountId,
@@ -38,7 +38,7 @@ export default class Datasets extends CollectionResource {
 }
 
 interface DataSetCreateRequest {
-  datasetName: string;
+  name: string;
   storageName: string;
   path: string;
   awsAccountId: string;

--- a/solutions/swb-reference/integration-tests/tests/isolated/datasets/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/datasets/create.test.ts
@@ -34,7 +34,7 @@ describe('datasets create negative tests', () => {
             statusCode: 400,
             error: 'Bad Request',
             message:
-              "requires property 'datasetName'. requires property 'storageName'. requires property 'path'. requires property 'awsAccountId'. requires property 'region'. requires property 'type'. requires property 'owner'"
+              "requires property 'name'. requires property 'storageName'. requires property 'path'. requires property 'awsAccountId'. requires property 'region'. requires property 'type'. requires property 'owner'"
           })
         );
       }

--- a/solutions/swb-reference/integration-tests/tests/isolated/datasets/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/datasets/create.test.ts
@@ -5,13 +5,11 @@
 import ClientSession from '../../../support/clientSession';
 import Setup from '../../../support/setup';
 import HttpError from '../../../support/utils/HttpError';
-import RandomTextGenerator from '../../../support/utils/randomTextGenerator';
 import { checkHttpError } from '../../../support/utils/utilities';
 
 describe('datasets create negative tests', () => {
   const setup: Setup = new Setup();
   let adminSession: ClientSession;
-  const randomTextGenerator = new RandomTextGenerator(setup.getSettings().get('runId'));
 
   beforeEach(() => {
     expect.hasAssertions();
@@ -25,101 +23,8 @@ describe('datasets create negative tests', () => {
     await setup.cleanup();
   });
 
-  const validLaunchParameters = {
-    datasetName: randomTextGenerator.getFakeText('fakeName'),
-    storageName: randomTextGenerator.getFakeText('fakeBucket'),
-    path: randomTextGenerator.getFakeText('fakePath'),
-    awsAccountId: randomTextGenerator.getFakeText('fakeAccount'),
-    region: randomTextGenerator.getFakeText('fakeRegion')
-  };
-
   describe('missing parameters', () => {
-    test('datasetName', async () => {
-      try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
-        delete invalidParam.datasetName;
-        await adminSession.resources.datasets.create(invalidParam, false);
-      } catch (e) {
-        checkHttpError(
-          e,
-          new HttpError(400, {
-            statusCode: 400,
-            error: 'Bad Request',
-            message: "requires property 'datasetName'"
-          })
-        );
-      }
-    });
-
-    test('path', async () => {
-      try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
-        delete invalidParam.path;
-        await adminSession.resources.datasets.create(invalidParam, false);
-      } catch (e) {
-        checkHttpError(
-          e,
-          new HttpError(400, {
-            statusCode: 400,
-            error: 'Bad Request',
-            message: "requires property 'path'"
-          })
-        );
-      }
-    });
-
-    test('storageName', async () => {
-      try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
-        delete invalidParam.storageName;
-        await adminSession.resources.datasets.create(invalidParam, false);
-      } catch (e) {
-        checkHttpError(
-          e,
-          new HttpError(400, {
-            statusCode: 400,
-            error: 'Bad Request',
-            message: "requires property 'storageName'"
-          })
-        );
-      }
-    });
-
-    test('awsAccountId', async () => {
-      try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
-        delete invalidParam.awsAccountId;
-        await adminSession.resources.datasets.create(invalidParam, false);
-      } catch (e) {
-        checkHttpError(
-          e,
-          new HttpError(400, {
-            statusCode: 400,
-            error: 'Bad Request',
-            message: "requires property 'awsAccountId'"
-          })
-        );
-      }
-    });
-
-    test('region', async () => {
-      try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
-        delete invalidParam.region;
-        await adminSession.resources.datasets.create(invalidParam, false);
-      } catch (e) {
-        checkHttpError(
-          e,
-          new HttpError(400, {
-            statusCode: 400,
-            error: 'Bad Request',
-            message: "requires property 'region'"
-          })
-        );
-      }
-    });
-
-    test('all parameters', async () => {
+    test('returns an error specifying the missing parameters', async () => {
       try {
         await adminSession.resources.datasets.create({}, false);
       } catch (e) {
@@ -129,7 +34,7 @@ describe('datasets create negative tests', () => {
             statusCode: 400,
             error: 'Bad Request',
             message:
-              "requires property 'datasetName'. requires property 'storageName'. requires property 'path'. requires property 'awsAccountId'. requires property 'region'"
+              "requires property 'datasetName'. requires property 'storageName'. requires property 'path'. requires property 'awsAccountId'. requires property 'region'. requires property 'type'. requires property 'owner'"
           })
         );
       }

--- a/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
@@ -31,10 +31,12 @@ describe('multiStep dataset integration test', () => {
       awsAccountId: settings.get('mainAccountId'),
       path: datasetName, // using same name to help potential troubleshooting
       datasetName,
-      region: settings.get('awsRegion')
+      region: settings.get('awsRegion'),
+      owner: `${settings.get('projectId')}#PA`,
+      type: 'internal'
     };
 
-    const { data: dataSet } = await adminSession.resources.datasets.create(dataSetBody);
+    const { data: dataSet } = await adminSession.resources.datasets.create(dataSetBody, false);
     expect(dataSet).toMatchObject({
       id: expect.stringMatching(dsUuidRegExp)
     });

--- a/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
@@ -78,8 +78,9 @@ describe('multiStep dataset integration test', () => {
     // Verify dataset has env access point listed in its external endpoints
     const { data: dataSetDetails } = await adminSession.resources.datasets.dataset(dataSet.id).get();
     // Dataset was created just for this test case, so we expect only one endpoint
-    expect(dataSetDetails.externalEndpoints).toMatchObject([
-      envDetails.ENDPOINTS[0].sk.split('ENDPOINT#')[1]
-    ]);
+    expect(dataSetDetails).toMatchObject({
+      ...dataSetBody,
+      externalEndpoints: [envDetails.ENDPOINTS[0].sk.split('ENDPOINT#')[1]]
+    });
   });
 });

--- a/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
@@ -30,7 +30,7 @@ describe('multiStep dataset integration test', () => {
       storageName: settings.get('DataSetsBucketName'),
       awsAccountId: settings.get('mainAccountId'),
       path: datasetName, // using same name to help potential troubleshooting
-      datasetName,
+      name: datasetName,
       region: settings.get('awsRegion'),
       owner: `${settings.get('projectId')}#PA`,
       type: 'internal'

--- a/workbench-core/base/README.md
+++ b/workbench-core/base/README.md
@@ -5,7 +5,7 @@
 ## Code Coverage
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-78.92%25-red.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-71.55%25-red.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-72.76%25-red.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-80.03%25-yellow.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-79%25-red.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-72.35%25-red.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-72.84%25-red.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-80.13%25-yellow.svg?style=flat) |
 # `base`
 
 > This package is intended to provide a base AWS Service class that encapsulates all the service clients and commands that the application currently requires. We use `aws-sdk` V3 to improve the load-time of the modules imported at runtime.

--- a/workbench-core/datasets/src/schemas/createDataSet.ts
+++ b/workbench-core/datasets/src/schemas/createDataSet.ts
@@ -10,7 +10,7 @@ const CreateDataSetSchema: Schema = {
   id: '/createDataSet',
   type: 'object',
   properties: {
-    datasetName: { type: 'string' },
+    name: { type: 'string' },
     storageName: { type: 'string' },
     path: { type: 'string' },
     awsAccountId: { type: 'string' },
@@ -19,7 +19,7 @@ const CreateDataSetSchema: Schema = {
     owner: { type: 'string' }
   },
   additionalProperties: false,
-  required: ['datasetName', 'storageName', 'path', 'awsAccountId', 'region', 'type', 'owner']
+  required: ['name', 'storageName', 'path', 'awsAccountId', 'region', 'type', 'owner']
 };
 
 export default CreateDataSetSchema;

--- a/workbench-core/datasets/src/schemas/createDataSet.ts
+++ b/workbench-core/datasets/src/schemas/createDataSet.ts
@@ -14,10 +14,12 @@ const CreateDataSetSchema: Schema = {
     storageName: { type: 'string' },
     path: { type: 'string' },
     awsAccountId: { type: 'string' },
-    region: { type: 'string' }
+    region: { type: 'string' },
+    type: { type: 'string' },
+    owner: { type: 'string' }
   },
   additionalProperties: false,
-  required: ['datasetName', 'storageName', 'path', 'awsAccountId', 'region']
+  required: ['datasetName', 'storageName', 'path', 'awsAccountId', 'region', 'type', 'owner']
 };
 
 export default CreateDataSetSchema;

--- a/workbench-core/example/infrastructure/integration-tests/support/resources/datasets/datasets.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/resources/datasets/datasets.ts
@@ -78,7 +78,7 @@ export default class Datasets extends CollectionResource {
     const region = this._settings.get('AwsRegion');
 
     return {
-      datasetName: resource.datasetName ?? dataSetName,
+      name: resource.name ?? dataSetName,
       path: resource.path ?? dataSetName,
       storageName: resource.storageName ?? storageName,
       awsAccountId: resource.awsAccountId ?? awsAccountId,
@@ -88,7 +88,7 @@ export default class Datasets extends CollectionResource {
 }
 
 interface DataSetCreateRequest {
-  datasetName: string;
+  name: string;
   storageName: string;
   path: string;
   awsAccountId: string;


### PR DESCRIPTION
# GALI-2125

Description of changes:
Added `owner` and `type` as required fields for `DataSet` creation. Fixed bug where `datasetName` was being used on the Create request instead of `name`, which is the field on the actual object.

Updated schema and integration tests.