### PR TITLE
fix: group management fixes

### DIFF
--- a/common/changes/@aws/workbench-core-authorization/fix-group-management-fixes_2023-01-04-00-10.json
+++ b/common/changes/@aws/workbench-core-authorization/fix-group-management-fixes_2023-01-04-00-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-authorization",
+      "comment": "Updated `createGroup` and `setGroupStatus` to not allow operations with incorrect statuses.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-authorization"
+}

--- a/workbench-core/authorization/README.md
+++ b/workbench-core/authorization/README.md
@@ -5,7 +5,7 @@
 # Code Coverage
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-97.71%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-97.97%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-98.87%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.68%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-97.8%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-98.09%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-98.87%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-97.77%25-brightgreen.svg?style=flat) |
 
 ## Description
 The authorization component is a flexible and extensible RBAC(role base access control) typescript library. It is designed using the plugin-architecture to allow for developers to easily implement and extend this library. This authorization component currently functions at the route based level.

--- a/workbench-core/authorization/src/dynamicAuthorization/dynamicAuthorizationService.test.ts
+++ b/workbench-core/authorization/src/dynamicAuthorization/dynamicAuthorizationService.test.ts
@@ -172,25 +172,6 @@ describe('DynamicAuthorizationService', () => {
         mockReturnValue
       );
     });
-
-    it('throws when the group status is not successfully set', async () => {
-      const mockReturnValue = new GroupNotFoundError();
-      mockGroupManagementPlugin.setGroupStatus = jest.fn().mockRejectedValue(mockReturnValue);
-
-      const params = { groupId, authenticatedUser: mockUser };
-
-      await expect(dynamicAuthzService.createGroup(params)).rejects.toThrow(GroupNotFoundError);
-      expect(auditServiceWriteSpy).toHaveBeenCalledWith(
-        {
-          actor: mockUser,
-          source: auditSource,
-          action: auditAction,
-          requestBody: params,
-          statusCode: 400
-        },
-        mockReturnValue
-      );
-    });
   });
 
   describe('deleteGroup', () => {

--- a/workbench-core/authorization/src/dynamicAuthorization/dynamicAuthorizationService.ts
+++ b/workbench-core/authorization/src/dynamicAuthorization/dynamicAuthorizationService.ts
@@ -134,10 +134,6 @@ export class DynamicAuthorizationService {
 
     try {
       const response = await this._groupManagementPlugin.createGroup(createGroupRequest);
-      await this._groupManagementPlugin.setGroupStatus({
-        groupId: createGroupRequest.groupId,
-        status: 'active'
-      });
 
       metadata.statusCode = 200;
       await this._auditService.write(metadata, response);

--- a/workbench-core/authorization/src/dynamicAuthorization/groupManagementPlugin.ts
+++ b/workbench-core/authorization/src/dynamicAuthorization/groupManagementPlugin.ts
@@ -141,6 +141,7 @@ export interface GroupManagementPlugin {
    * @throws {@link PluginConfigurationError} - plugin has a configuration error
    * @throws {@link GroupNotFoundError} - group not found error
    * @throws {@link TooManyRequestsError} - too many requests error
+   * @throws {@link ForbiddenError} - invalid state transition
    */
   setGroupStatus(request: SetGroupStatusRequest): Promise<SetGroupStatusResponse>;
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Added check to `createGroup` to not allow groups to be created if theyre pending delete
- Added check to `setGroupStatus` to not allow status to go from `delete_pending` to `active`
- Added/updated corresponding unit/integration tests

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.