### PR TITLE
test: account integ tests

### DIFF
--- a/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/create.test.ts
@@ -47,7 +47,7 @@ describe('awsAccounts create negative tests', () => {
               statusCode: 400,
               error: 'Bad Request',
               message:
-                "requires property 'awsAccountId'. requires property 'envMgmtRoleArn'. requires property 'hostingAccountHandlerRoleArn'. requires property 'name'. requires property 'externalId'"
+                'name: Required. awsAccountId: Required. envMgmtRoleArn: Required. hostingAccountHandlerRoleArn: Required. externalId: Required'
             })
           );
         }

--- a/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/update.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/update.test.ts
@@ -50,7 +50,7 @@ describe('awsAccounts update negative tests', () => {
             new HttpError(400, {
               statusCode: 400,
               error: 'Bad Request',
-              message: 'name is not of a type(s) string'
+              message: 'name: Expected string, received number'
             })
           );
         }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fixes the integ tests that failed here
https://github.com/aws-solutions/solution-spark-on-aws/actions/runs/3906737149/jobs/6675321781

* The isolated accounts test failed because switching to Zod parser caused the error message to look different from what the tests expected.
* The costCenter test failed because the account DDB entry was missing the `name` field in the test environment. I manually fixed that in the test environment. 


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.