### PR TITLE
test: added refreshAccessToken integration tests

### DIFF
--- a/workbench-core/example/infrastructure/integration-tests/support/clientSession.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/clientSession.ts
@@ -18,7 +18,7 @@ export default class ClientSession {
   private _setup: Setup;
   public resources: Resources;
 
-  public constructor(setup: Setup, accessToken?: string) {
+  public constructor(setup: Setup, accessToken?: string, refreshToken?: string) {
     this._settings = setup.getSettings();
     this._setup = setup;
     this._isAnonymousSession = accessToken === undefined;
@@ -31,11 +31,11 @@ export default class ClientSession {
     } = { 'Content-Type': 'application/json' };
 
     // For anonymous sessions, access token cookie is not required
-    if (accessToken) {
+    if (accessToken && refreshToken) {
       const csrf = new Csrf();
       const secret = csrf.secretSync();
       const token = csrf.create(secret);
-      headers.Cookie = `access_token=${accessToken};_csrf=${secret};`;
+      headers.Cookie = `access_token=${accessToken};refresh_token=${refreshToken};_csrf=${secret};`;
       headers['csrf-token'] = token;
     }
 

--- a/workbench-core/example/infrastructure/integration-tests/support/resources/authentication/authentication.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/resources/authentication/authentication.ts
@@ -92,4 +92,15 @@ export default class Authentication extends CollectionResource {
 
     return this._axiosInstance.get('loggedIn', { headers });
   }
+
+  public async refresh(config: { includeRefreshToken: boolean }): Promise<AxiosResponse> {
+    const headers: AxiosRequestHeaders = {};
+    const invalidToken = 'invalidToken';
+
+    if (config.includeRefreshToken) {
+      headers.Cookie = `refresh_token=${invalidToken};`;
+    }
+
+    return this._axiosInstance.get('refresh', { headers });
+  }
 }

--- a/workbench-core/example/infrastructure/integration-tests/support/setup.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/setup.ts
@@ -38,7 +38,7 @@ export default class Setup {
 
     const secretsService = new SecretsService(new AwsService({ region: awsRegion }).clients.ssm);
     const cognitoTokenService = new CognitoTokenService(awsRegion, secretsService);
-    const { accessToken } = await cognitoTokenService.generateCognitoToken({
+    const { accessToken, refreshToken } = await cognitoTokenService.generateCognitoToken({
       userPoolId,
       clientId,
       rootUserNameParamStorePath,
@@ -48,7 +48,7 @@ export default class Setup {
     const decodedToken: { sub: string } = jwt_decode(accessToken);
     this._settings.set('rootUserId', decodedToken.sub);
 
-    const session = this._getClientSession(accessToken);
+    const session = this._getClientSession(accessToken, refreshToken);
     this._sessions.push(session);
 
     return session;
@@ -92,7 +92,7 @@ export default class Setup {
     return this._settings;
   }
 
-  private _getClientSession(accessToken?: string): ClientSession {
-    return new ClientSession(this, accessToken);
+  private _getClientSession(accessToken?: string, refreshToken?: string): ClientSession {
+    return new ClientSession(this, accessToken, refreshToken);
   }
 }

--- a/workbench-core/example/infrastructure/integration-tests/tests/authentication/routeHandler.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/authentication/routeHandler.test.ts
@@ -79,6 +79,7 @@ describe('authentication route handler integration tests', () => {
 
       expect(data.loggedIn).toBe(false);
     });
+
     it('should return false for an invalid access token', async () => {
       const { data } = await anonymousSession.resources.authentication.loggedIn({
         access: false,
@@ -87,6 +88,7 @@ describe('authentication route handler integration tests', () => {
 
       expect(data.loggedIn).toBe(false);
     });
+
     it('should return false for an invalid refresh and access tokens', async () => {
       const { data } = await anonymousSession.resources.authentication.loggedIn({
         access: true,
@@ -95,6 +97,7 @@ describe('authentication route handler integration tests', () => {
 
       expect(data.loggedIn).toBe(false);
     });
+
     it('should return false if no tokens are provided', async () => {
       const { data } = await anonymousSession.resources.authentication.loggedIn({
         access: false,
@@ -102,6 +105,31 @@ describe('authentication route handler integration tests', () => {
       });
 
       expect(data.loggedIn).toBe(false);
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('should return the id token if the access token is successfully refreshed', async () => {
+      const admin = await setup.createAdminSession();
+      const { data } = await admin.resources.authentication.refresh({ includeRefreshToken: false });
+
+      expect(data.idToken).toBeDefined();
+    });
+
+    it('should throw 401 if there is no access token present', async () => {
+      await expect(
+        anonymousSession.resources.authentication.refresh({
+          includeRefreshToken: false
+        })
+      ).rejects.toThrow(new HttpError(401, {}));
+    });
+
+    it('should throw 401 if the access token is invalid', async () => {
+      await expect(
+        anonymousSession.resources.authentication.refresh({
+          includeRefreshToken: true
+        })
+      ).rejects.toThrow(new HttpError(401, {}));
     });
   });
 });


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Added integration tests for the authentication package's `refreshAccessToken` API

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.