### PR TITLE
test: added integration tests for getTokensFromAuthorizationCode

### DIFF
--- a/workbench-core/example/infrastructure/integration-tests/support/resources/authentication/authentication.ts
+++ b/workbench-core/example/infrastructure/integration-tests/support/resources/authentication/authentication.ts
@@ -116,4 +116,26 @@ export default class Authentication extends CollectionResource {
 
     return this._axiosInstance.post('logout', undefined, { headers });
   }
+
+  public async token(config: {
+    code?: string;
+    codeVerifier?: string;
+    origin?: string;
+  }): Promise<AxiosResponse> {
+    const headers: AxiosRequestHeaders = {
+      Cookie: `_csrf=${this._csrfSecret};`,
+      ['csrf-token']: this._csrfToken
+    };
+
+    if (config.origin) {
+      headers.origin = config.origin;
+    }
+
+    const body = {
+      code: config.code,
+      codeVerifier: config.codeVerifier
+    };
+
+    return this._axiosInstance.post('token', body, { headers });
+  }
 }

--- a/workbench-core/example/infrastructure/integration-tests/tests/authentication/routeHandler.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/authentication/routeHandler.test.ts
@@ -161,4 +161,40 @@ describe('authentication route handler integration tests', () => {
       );
     });
   });
+
+  describe('getTokensFromAuthorizationCode', () => {
+    let code: string;
+    let codeVerifier: string;
+    let origin: string;
+
+    beforeEach(() => {
+      code = 'fakeAuthorizationCode';
+      codeVerifier = 'fakeCodeVerifier';
+      origin = 'fakeOrigin';
+    });
+
+    it('should throw 401 if the code param is invalid', async () => {
+      await expect(
+        anonymousSession.resources.authentication.token({ code, codeVerifier, origin })
+      ).rejects.toThrow(new HttpError(401, {}));
+    });
+
+    it('should throw 400 if the code param is missing from the request body', async () => {
+      await expect(anonymousSession.resources.authentication.token({ codeVerifier, origin })).rejects.toThrow(
+        new HttpError(400, {})
+      );
+    });
+
+    it('should throw 400 if the codeVerifier param is missing from the request body', async () => {
+      await expect(anonymousSession.resources.authentication.token({ code, origin })).rejects.toThrow(
+        new HttpError(400, {})
+      );
+    });
+
+    it('should throw 400 if the origin header is not present', async () => {
+      await expect(anonymousSession.resources.authentication.token({ code, codeVerifier })).rejects.toThrow(
+        new HttpError(400, {})
+      );
+    });
+  });
 });


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- added integration tests for the authentication package's `getTokensFromAuthorizationCode` API

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.