### PR TITLE
fix: updateEnvironment params order was backwards

### DIFF
--- a/common/changes/@aws/swb-app/kevpark-update-env-params-fix_2023-02-16-16-52.json
+++ b/common/changes/@aws/swb-app/kevpark-update-env-params-fix_2023-02-16-16-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "Update order of params for updateEnvironment and getEnvironment",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/solutions/swb-app/src/projectEnvironmentRoutes.ts
+++ b/solutions/swb-app/src/projectEnvironmentRoutes.ts
@@ -37,7 +37,7 @@ export function setUpProjectEnvRoutes(
         } catch (e) {
           // Update error state
           const errorMessage = e.message as string;
-          await projectEnvironmentService.updateEnvironment(env.id!, env.projectId, {
+          await projectEnvironmentService.updateEnvironment(env.projectId, env.id!, {
             error: { type: 'LAUNCH', value: errorMessage },
             status: 'FAILED'
           });

--- a/solutions/swb-app/src/projectEnvs/projectEnvPlugin.ts
+++ b/solutions/swb-app/src/projectEnvs/projectEnvPlugin.ts
@@ -31,11 +31,11 @@ export interface ProjectEnvPlugin {
 
   /**
    *
-   * @param envId - Environment Id
    * @param projectId - Project Id
+   * @param envId - Environment Id
    * @param includeMetadata - If true we get all entries where pk = envId, instead of just the entry where pk = envId and sk = envId
    */
-  getEnvironment(envId: string, projectId: string, includeMetadata: boolean): Promise<Environment>;
+  getEnvironment(projectId: string, envId: string, includeMetadata: boolean): Promise<Environment>;
 
   /**
    * List Environments associated with Project
@@ -56,13 +56,13 @@ export interface ProjectEnvPlugin {
   /**
    * Update Environment associated with Project
    *
-   * @param envId - Environment Id
    * @param projectId - Project Id
+   * @param envId - Environment Id
    * @param updatedValues - Key Value pairs to be updated
    */
   updateEnvironment(
-    envId: string,
     projectId: string,
+    envId: string,
     updatedValues: {
       [key: string]:
         | string

--- a/solutions/swb-reference/integration-tests/support/resources/environments/environments.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/environments/environments.ts
@@ -43,7 +43,6 @@ export default class Environments extends CollectionResource {
 
   public async listProjectEnvironments(projectId?: string): Promise<AxiosResponse> {
     projectId = projectId ?? this._settings.get('projectId');
-    console.log(`kvpark ${projectId}`);
     this._api = `projects/${projectId}/environments`;
     const response = super.get();
     this._api = 'environments';


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Updated order of params for projectEnvironmentService/Plugin so that Project always comes first.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.