### PR TITLE
fix(ssh-keys): fix ssh keys route mapping to not have duplicate

### DIFF
--- a/common/changes/@aws/swb-app/maghirardelli-fix-ssh-key-route-mapping_2023-02-16-21-03.json
+++ b/common/changes/@aws/swb-app/maghirardelli-fix-ssh-key-route-mapping_2023-02-16-21-03.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "fix ssh key route mapping",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/solutions/swb-app/src/staticRouteConfig.ts
+++ b/solutions/swb-app/src/staticRouteConfig.ts
@@ -429,9 +429,7 @@ export const routesMap: RoutesMap = {
         action: 'READ',
         subject: 'SshKey'
       }
-    ]
-  },
-  [`/projects/${resourceTypeToKey.project.toLowerCase()}-${uuidRegExpAsString}/sshKeys`]: {
+    ],
     POST: [
       {
         action: 'CREATE',


### PR DESCRIPTION
Issue #, if available:

Description of changes:
fixing static route config. The merge resolution created two mappings of the same route to different permissions, overwriting one needed for the integ tests.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.