### PR TITLE
feat: list data set access permissions

### DIFF
--- a/common/changes/@aws/swb-app/atmikev-GALI-2279_ListDataSetAccessPermissions_2023-02-20-22-54.json
+++ b/common/changes/@aws/swb-app/atmikev-GALI-2279_ListDataSetAccessPermissions_2023-02-20-22-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "added ListDataSetAccessPermission functionality",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/common/changes/@aws/workbench-core-accounts/atmikev-GALI-2279_ListDataSetAccessPermissions_2023-02-20-23-01.json
+++ b/common/changes/@aws/workbench-core-accounts/atmikev-GALI-2279_ListDataSetAccessPermissions_2023-02-20-23-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-accounts",
+      "comment": "updated types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-accounts"
+}

--- a/common/changes/@aws/workbench-core-datasets/atmikev-GALI-2279_ListDataSetAccessPermissions_2023-02-20-22-54.json
+++ b/common/changes/@aws/workbench-core-datasets/atmikev-GALI-2279_ListDataSetAccessPermissions_2023-02-20-22-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-datasets",
+      "comment": "added ListDataSetAccessPermission functionality",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-datasets"
+}

--- a/solutions/swb-app/README.md
+++ b/solutions/swb-app/README.md
@@ -5,6 +5,6 @@
 # Code Coverage
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-82.25%25-yellow.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-100%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-82.25%25-yellow.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-80.31%25-yellow.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-100%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-100%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-80.31%25-yellow.svg?style=flat) |
 
 This project is the routing package for `swb-reference`. It is used by `swb-reference` to generate routes for SWB API. Please refer  [here](../swb-reference/README.md) for more information on how to use this project.

--- a/solutions/swb-app/src/dataSetRoutes.ts
+++ b/solutions/swb-app/src/dataSetRoutes.ts
@@ -15,6 +15,10 @@ import {
 } from './dataSets/createExternalEndpointRequestParser';
 import { DataSetPlugin } from './dataSets/dataSetPlugin';
 import {
+  ListDataSetAccessPermissionsRequest,
+  ListDataSetAccessPermissionsRequestParser
+} from './dataSets/listDataSetAccessPermissionsRequestParser';
+import {
   ProjectAddAccessRequest,
   ProjectAddAccessRequestParser
 } from './dataSets/projectAddAccessRequestParser';
@@ -146,6 +150,21 @@ export function setUpDSRoutes(router: Router, dataSetService: DataSetPlugin): vo
       await dataSetService.removeAccessForProject(validatedRequest);
 
       res.status(204).send();
+    })
+  );
+
+  router.get(
+    '/datasets/:datasetId/permissions',
+    wrapAsync(async (req: Request, res: Response) => {
+      const validatedRequest = validateAndParse<ListDataSetAccessPermissionsRequest>(
+        ListDataSetAccessPermissionsRequestParser,
+        {
+          ...req.query,
+          authenticatedUser: res.locals.user,
+          dataSetId: req.params.datasetId
+        }
+      );
+      res.send(await dataSetService.listDataSetAccessPermissions(validatedRequest));
     })
   );
 

--- a/solutions/swb-app/src/dataSets/dataSetPlugin.ts
+++ b/solutions/swb-app/src/dataSets/dataSetPlugin.ts
@@ -11,6 +11,7 @@ import { DataSetAddExternalEndpointResponse } from './dataSetAddExternalEndpoint
 import { DataSetExternalEndpointRequest } from './dataSetExternalEndpointRequest';
 import { DataSetStoragePlugin } from './dataSetStoragePlugin';
 import { GetAccessPermissionRequest } from './getAccessPermissionRequestParser';
+import { ListDataSetAccessPermissionsRequest } from './listDataSetAccessPermissionsRequestParser';
 import { PermissionsResponse } from './permissionsResponseParser';
 import { ProjectAddAccessRequest } from './projectAddAccessRequestParser';
 import { ProjectRemoveAccessRequest } from './projectRemoveAccessRequestParser';
@@ -26,6 +27,7 @@ export interface DataSetPlugin {
   ): Promise<DataSetAddExternalEndpointResponse>;
   getDataSet(dataSetId: string, authenticatedUser: AuthenticatedUser): Promise<DataSet>;
   listDataSets(user: AuthenticatedUser): Promise<DataSet[]>;
+  listDataSetAccessPermissions(request: ListDataSetAccessPermissionsRequest): Promise<PermissionsResponse>;
 
   addAccessPermission(params: AddRemoveAccessPermissionRequest): Promise<PermissionsResponse>;
   getAccessPermissions(params: GetAccessPermissionRequest): Promise<PermissionsResponse>;

--- a/solutions/swb-app/src/dataSets/listDataSetAccessPermissionsRequestParser.ts
+++ b/solutions/swb-app/src/dataSets/listDataSetAccessPermissionsRequestParser.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @rushstack/typedef-var
+import { z } from 'zod';
+import { AuthenticatedUserParser } from '../users/authenticatedUser';
+
+// eslint-disable-next-line @rushstack/typedef-var
+export const ListDataSetAccessPermissionsRequestParser = z
+  .object({
+    dataSetId: z.string(),
+    authenticatedUser: AuthenticatedUserParser,
+    paginationToken: z.string().optional()
+  })
+  .strict();
+
+export type ListDataSetAccessPermissionsRequest = z.infer<typeof ListDataSetAccessPermissionsRequestParser>;

--- a/solutions/swb-app/src/dataSets/listDataSetAccessPermissionsRequestParser.ts
+++ b/solutions/swb-app/src/dataSets/listDataSetAccessPermissionsRequestParser.ts
@@ -1,3 +1,8 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
 // eslint-disable-next-line @rushstack/typedef-var
 import { z } from 'zod';
 import { AuthenticatedUserParser } from '../users/authenticatedUser';

--- a/solutions/swb-app/src/staticPermissionsConfig.ts
+++ b/solutions/swb-app/src/staticPermissionsConfig.ts
@@ -113,6 +113,11 @@ const adminPermissions: Permission[] = [
   },
   {
     effect: 'ALLOW',
+    action: 'READ',
+    subject: 'DatasetPermission'
+  },
+  {
+    effect: 'ALLOW',
     action: 'CREATE',
     subject: 'Environment'
   },

--- a/solutions/swb-app/src/staticRouteConfig.ts
+++ b/solutions/swb-app/src/staticRouteConfig.ts
@@ -112,6 +112,14 @@ export const routesMap: RoutesMap = {
       }
     ]
   },
+  [`/datasets/${resourceTypeToKey.dataset.toLowerCase()}-${uuidRegExpAsString}/permissions`]: {
+    GET: [
+      {
+        action: 'READ',
+        subject: 'DatasetPermission'
+      }
+    ]
+  },
   '/datasets/import': {
     POST: [
       {

--- a/solutions/swb-reference/README.md
+++ b/solutions/swb-reference/README.md
@@ -25,7 +25,7 @@ To test the new Service Workbench on AWS v2 r0.1.0, follow the deployment instru
 
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-94.88%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-82.05%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-84.12%25-yellow.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-94.82%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-94.91%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-82.05%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-84.37%25-yellow.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-94.86%25-brightgreen.svg?style=flat) |
 
 ## Requirements
 

--- a/solutions/swb-reference/integration-tests/support/resources/datasets/dataset.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/datasets/dataset.ts
@@ -34,6 +34,10 @@ export default class Dataset extends Resource {
     return this._axiosInstance.delete(`/projects/${projectId}/datasets/${this._id}/relationships`);
   }
 
+  public async listAccessPermissions(): Promise<AxiosResponse> {
+    return this._axiosInstance.get(`/datasets/${this._id}/permissions`);
+  }
+
   protected async cleanup(): Promise<void> {
     const defAdminSession = await this._setup.getDefaultAdminSession();
     const { data: resource } = await defAdminSession.resources.datasets.dataset(this._id).get();

--- a/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
@@ -3,6 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 import { CreateDataSetRequestParser } from '@aws/swb-app/lib/dataSets/createDataSetRequestParser';
+import { DataSetPermission } from '@aws/swb-app/lib/dataSets/dataSetPermissionParser';
 import { getProjectAdminRole, getResearcherRole } from '../../../src/utils/roleUtils';
 import ClientSession from '../../support/clientSession';
 import Setup from '../../support/setup';
@@ -64,7 +65,7 @@ describe('multiStep dataset integration test', () => {
         {
           identity: getResearcherRole(projectId),
           identityType: 'GROUP',
-          accessLevel: 'read-only'
+          accessLevel: 'read-write'
         }
       ]
     });
@@ -131,6 +132,28 @@ describe('multiStep dataset integration test', () => {
     await adminSession.resources.datasets
       .dataset(dataSet.id)
       .associateWithProject(unassociatedProject.id, 'read-only');
+
+    console.log('CHECK PROJECT PERMISSIONS FOR DATASET');
+    const { data: responseData } = await adminSession.resources.datasets
+      .dataset(dataSet.id)
+      .listAccessPermissions();
+    const sortedActual: DataSetPermission[] = responseData.data.permissions.sort(
+      (p1: DataSetPermission, p2: DataSetPermission) => p1.accessLevel < p2.accessLevel
+    );
+    const expected: DataSetPermission[] = [
+      {
+        accessLevel: 'read-write',
+        identity: `${projectId}#Researcher`,
+        identityType: 'GROUP'
+      },
+      {
+        accessLevel: 'read-only',
+        identity: `${unassociatedProject.id}#ProjectAdmin`,
+        identityType: 'GROUP'
+      }
+    ];
+
+    expect(sortedActual).toEqual(expected);
 
     console.log('DISASSOCIATE FROM PROJECT');
     await adminSession.resources.datasets.dataset(dataSet.id).disassociateFromProject(unassociatedProject.id);

--- a/solutions/swb-reference/src/services/dataSetService.test.ts
+++ b/solutions/swb-reference/src/services/dataSetService.test.ts
@@ -10,6 +10,7 @@ import {
   DataSetStoragePlugin,
   PermissionsResponse
 } from '@aws/swb-app';
+import { ListDataSetAccessPermissionsRequestParser } from '@aws/swb-app/lib/dataSets/listDataSetAccessPermissionsRequestParser';
 import { ProjectAddAccessRequest } from '@aws/swb-app/lib/dataSets/projectAddAccessRequestParser';
 import { ProjectRemoveAccessRequest } from '@aws/swb-app/lib/dataSets/projectRemoveAccessRequestParser';
 import {
@@ -651,6 +652,36 @@ describe('DataSetService', () => {
           });
         });
       });
+    });
+  });
+
+  describe('listDataSetAccessPermissions', () => {
+    beforeEach(() => {
+      const response: PermissionsResponse = {
+        data: {
+          dataSetId: mockDataSet.id!,
+          permissions: [
+            {
+              accessLevel: 'read-only',
+              identity: `${projectId}#Researcher`,
+              identityType: 'GROUP'
+            }
+          ]
+        }
+      };
+      mockWorkbenchDataSetService.getAllDataSetAccessPermissions = jest.fn().mockReturnValueOnce(response);
+    });
+
+    test('it delegates to the workbench-core DataSetService method', async () => {
+      const request = ListDataSetAccessPermissionsRequestParser.parse({
+        dataSetId: mockDataSet.id!,
+        authenticatedUser: mockUser,
+        paginationToken: ''
+      });
+
+      await dataSetService.listDataSetAccessPermissions(request);
+
+      expect(mockWorkbenchDataSetService.getAllDataSetAccessPermissions).toHaveBeenCalled();
     });
   });
 });

--- a/solutions/swb-reference/src/services/dataSetService.ts
+++ b/solutions/swb-reference/src/services/dataSetService.ts
@@ -14,6 +14,7 @@ import {
   PermissionsResponse,
   PermissionsResponseParser
 } from '@aws/swb-app';
+import { ListDataSetAccessPermissionsRequest } from '@aws/swb-app/lib/dataSets/listDataSetAccessPermissionsRequestParser';
 import { ProjectAddAccessRequest } from '@aws/swb-app/lib/dataSets/projectAddAccessRequestParser';
 import { ProjectRemoveAccessRequest } from '@aws/swb-app/lib/dataSets/projectRemoveAccessRequestParser';
 import {
@@ -127,6 +128,18 @@ export class DataSetService implements DataSetPlugin {
 
   public listDataSets(user: AuthenticatedUser): Promise<DataSet[]> {
     return this._workbenchDataSetService.listDataSets(user);
+  }
+
+  public async listDataSetAccessPermissions(
+    request: ListDataSetAccessPermissionsRequest
+  ): Promise<PermissionsResponse> {
+    const response = await this._workbenchDataSetService.getAllDataSetAccessPermissions(
+      request.dataSetId,
+      request.authenticatedUser,
+      request.paginationToken
+    );
+
+    return PermissionsResponseParser.parse(response);
   }
 
   public async provisionDataSet(request: CreateProvisionDatasetRequest): Promise<DataSet> {

--- a/workbench-core/accounts/README.md
+++ b/workbench-core/accounts/README.md
@@ -7,5 +7,5 @@
 
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-93.69%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-91.17%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-94.73%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.6%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-93.64%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-91.17%25-brightgreen.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-94.68%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-93.56%25-brightgreen.svg?style=flat) |
 

--- a/workbench-core/datasets/src/dataSetService.ts
+++ b/workbench-core/datasets/src/dataSetService.ts
@@ -46,6 +46,7 @@ export class DataSetService {
    * @param masterDbProvider - an instance of {@link DataSetMetadataPlugin} configured for the solution's
    * main account. This plugin will reference the table which will track all DataSets even if some file
    * metadata resides in external accounts.
+   * @param authorizationPlugin - the plugin used for authorization checks
    * @returns - the intialized {@link DataSetService}.
    */
   public constructor(
@@ -140,6 +141,7 @@ export class DataSetService {
    * @param dataSetId - the ID of the DataSet to remove.
    * @param checkDependency - function to validate whether all required prerequisites are met before removing dataset.
    * If prerequisites are not met - function should throw error.
+   * @param authenticatedUser - the user making the request
    * @throws DataSetHasEndpontError - if the dataset has external endpoints assigned.
    */
   public async removeDataSet(
@@ -289,6 +291,7 @@ export class DataSetService {
    * Get details on a particular DataSet.
    *
    * @param dataSetId - the Id of the DataSet for which details are desired.
+   * @param authenticatedUser - the user making the request
    * @returns - the DataSet object associated with that DataSet.
    */
   public async getDataSet(dataSetId: string, authenticatedUser: AuthenticatedUser): Promise<DataSet> {
@@ -331,16 +334,14 @@ export class DataSetService {
    * @param dataSetId - the name of the DataSet from which the endpoint will be removed.
    * @param externalEndpointId - the ID of the endpoint to remove.
    * @param storageProvider - an instance of {@link DataSetsStoragePlugin} initialized with permissions
+   * @param authenticatedUser - the user making the request
    * to modify the target DataSet's underlying storage.
    */
   public async removeDataSetExternalEndpoint(
     dataSetId: string,
     externalEndpointId: string,
     storageProvider: DataSetsStoragePlugin,
-    authenticatedUser: {
-      id: string;
-      roles: string[];
-    }
+    authenticatedUser: AuthenticatedUser
   ): Promise<void> {
     const metadata: Metadata = {
       actor: authenticatedUser,
@@ -460,6 +461,7 @@ export class DataSetService {
    * @param endpointId - the ID of the endpoint.
    * @param externalRoleArn  - the ARN of the role to add to the endpoint.
    * @param storageProvider - an instance of DataSetsStoragePlugin intialized to access the endpoint.
+   * @param authenticatedUser - the user making the request
    * @param kmsKeyArn - an optional ARN to a KMS key used to encrypt data in the DataSet.
    */
   public async addRoleToExternalEndpoint(
@@ -467,10 +469,7 @@ export class DataSetService {
     endpointId: string,
     externalRoleArn: string,
     storageProvider: DataSetsStoragePlugin,
-    authenticatedUser: {
-      id: string;
-      roles: string[];
-    },
+    authenticatedUser: AuthenticatedUser,
     kmsKeyArn?: string
   ): Promise<void> {
     const metadata: Metadata = {
@@ -516,12 +515,13 @@ export class DataSetService {
    * Get the details of an external endpoint.
    * @param dataSetId - the ID of the DataSet.
    * @param endpointId - the id of the EndPoint.
+   * @param authenticatedUser - the user making the request
    * @returns - the details of the endpoint.
    */
   public async getExternalEndPoint(
     dataSetId: string,
     endpointId: string,
-    authenticatedUser: { id: string; roles: string[] }
+    authenticatedUser: AuthenticatedUser
   ): Promise<ExternalEndpoint> {
     const metadata: Metadata = {
       actor: authenticatedUser,
@@ -548,6 +548,7 @@ export class DataSetService {
    * @param fileName - the name of the file to upload.
    * @param timeToLiveSeconds - length of time (in seconds) the URL is valid.
    * @param storageProvider - an instance of DataSetsStoragePlugin intialized to access the endpoint.
+   * @param authenticatedUser - the user making the request
    * @returns the presigned URL
    */
   public async getPresignedSinglePartUploadUrl(
@@ -555,10 +556,7 @@ export class DataSetService {
     fileName: string,
     timeToLiveSeconds: number,
     storageProvider: DataSetsStoragePlugin,
-    authenticatedUser: {
-      id: string;
-      roles: string[];
-    }
+    authenticatedUser: AuthenticatedUser
   ): Promise<string> {
     const metadata: Metadata = {
       actor: authenticatedUser,
@@ -653,7 +651,7 @@ export class DataSetService {
    */
   public async getDataSetAccessPermissions(
     params: GetAccessPermissionRequest,
-    authenticatedUser: { id: string; roles: string[] }
+    authenticatedUser: AuthenticatedUser
   ): Promise<PermissionsResponse> {
     const metadata: Metadata = {
       actor: authenticatedUser,
@@ -677,14 +675,14 @@ export class DataSetService {
   /**
    * Get all access permissions (read-only or read-write) associated with the dataset.
    *
-   * @param dataSetId - the id of the dataset for which permmissions are to be obtained.
+   * @param dataSetId - the id of the dataset for which permissions are to be obtained.
    * @param authenticatedUser - the 'id' of the user and that user's roles.
-   * @param pageToken - a token from a pervious query to continue recieving results.
+   * @param pageToken - a token from a previous query to continue receiving results.
    * @returns a {@link PermissionsResponse} object containing the permissions found.
    */
   public async getAllDataSetAccessPermissions(
     dataSetId: string,
-    authenticatedUser: { id: string; roles: string[] },
+    authenticatedUser: AuthenticatedUser,
     pageToken?: string
   ): Promise<PermissionsResponse> {
     const metadata: Metadata = {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added endpoint and tests to allow a user to get the permissions associated with a data set so they can see who has access to their dataset

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.