### PR TITLE
fix(integ tests): add afterEach step to cleanup environments

### DIFF
--- a/solutions/swb-reference/integration-tests/tests/isolated/datasets/delete.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/datasets/delete.test.ts
@@ -69,6 +69,10 @@ describe('datasets delete negative tests', () => {
     dataSet = newDataSet;
   });
 
+  afterEach(async () => {
+    await setup.cleanup();
+  });
+
   describe('when the dataset does not exist', () => {
     test('it returns a 404', async () => {
       try {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
add afterEach to cleanup after integ test suite so environments don't stick around

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.