### PR TITLE
feat: verify cost center was not deleted before creating project

### DIFF
--- a/common/changes/@aws/workbench-core-accounts/topic-verifyCostCenterWasNotDeletedBeforeCreatingProject_2023-02-20-17-55.json
+++ b/common/changes/@aws/workbench-core-accounts/topic-verifyCostCenterWasNotDeletedBeforeCreatingProject_2023-02-20-17-55.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-accounts",
+      "comment": "Verify that Cost Center was not deleted before creating new Project",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-accounts"
+}

--- a/solutions/swb-reference/integration-tests/tests/isolated/costCenter/get.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/costCenter/get.test.ts
@@ -35,4 +35,28 @@ describe('Get Cost Center negative tests', () => {
       }
     });
   });
+
+  describe('with Cost Center that does was deleted', () => {
+    test('it throw 404 error', async () => {
+      const accountId = setup.getSettings().get('defaultHostingAccountId');
+      const { data: createdCostCenter } = await adminSession.resources.costCenters.create({
+        accountId,
+        name: 'costCenterA'
+      });
+
+      await adminSession.resources.costCenters.costCenter(createdCostCenter.id).softDelete();
+
+      try {
+        await adminSession.resources.costCenters.costCenter(createdCostCenter.id).get();
+      } catch (e) {
+        checkHttpError(
+          e,
+          new HttpError(404, {
+            error: 'Not Found',
+            message: `Cost center ${createdCostCenter.id} was deleted`
+          })
+        );
+      }
+    });
+  });
 });

--- a/solutions/swb-reference/integration-tests/tests/isolated/projects/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/projects/create.test.ts
@@ -157,5 +157,37 @@ describe('Create Project negative tests', () => {
         }
       });
     });
+
+    describe('that was deleted', () => {
+      beforeEach(async () => {
+        const { data: costCenter } = await adminSession.resources.costCenters.create({
+          name: 'project integration test cost center',
+          accountId: setup.getSettings().get('defaultHostingAccountId'),
+          description: 'a test costcenter'
+        });
+        costCenterId = costCenter.id;
+
+        await adminSession.resources.costCenters.costCenter(costCenterId).softDelete();
+      });
+
+      test('it throws 400 error', async () => {
+        try {
+          existingProjectName = randomTextGenerator.getFakeText('test-project-name');
+          await adminSession.resources.projects.create({
+            name: existingProjectName,
+            description: 'Project for TOP SECRET dragon research',
+            costCenterId
+          });
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(404, {
+              error: 'Not Found',
+              message: `Cost center ${costCenterId} was deleted`
+            })
+          );
+        }
+      });
+    });
   });
 });

--- a/workbench-core/accounts/src/constants/costCenterStatus.ts
+++ b/workbench-core/accounts/src/constants/costCenterStatus.ts
@@ -1,0 +1,9 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+export enum CostCenterStatus {
+  AVAILABLE = 'AVAILABLE',
+  DELETED = 'DELETED'
+}

--- a/workbench-core/accounts/src/models/costCenters/costCenter.ts
+++ b/workbench-core/accounts/src/models/costCenters/costCenter.ts
@@ -4,9 +4,10 @@
  */
 
 import { z } from 'zod';
+import { CostCenterStatus } from '../../constants/costCenterStatus';
 
 // eslint-disable-next-line @rushstack/typedef-var
-export const CostCenterWithResourceTypeParser = z.object({
+export const CostCenterParser = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
@@ -22,11 +23,7 @@ export const CostCenterWithResourceTypeParser = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   dependency: z.string(),
-  resourceType: z.enum(['costCenter', 'costCenter_deleted'])
+  status: z.nativeEnum(CostCenterStatus)
 });
 
-// eslint-disable-next-line @rushstack/typedef-var
-export const CostCenterParser = CostCenterWithResourceTypeParser.omit({ resourceType: true });
-
-export type CostCenterWithResourceType = z.infer<typeof CostCenterWithResourceTypeParser>;
 export type CostCenter = z.infer<typeof CostCenterParser>;

--- a/workbench-core/accounts/src/models/costCenters/costCenter.ts
+++ b/workbench-core/accounts/src/models/costCenters/costCenter.ts
@@ -6,7 +6,7 @@
 import { z } from 'zod';
 
 // eslint-disable-next-line @rushstack/typedef-var
-export const CostCenterParser = z.object({
+export const CostCenterWithResourceTypeParser = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
@@ -21,7 +21,12 @@ export const CostCenterParser = z.object({
   accountId: z.string(),
   createdAt: z.string(),
   updatedAt: z.string(),
-  dependency: z.string()
+  dependency: z.string(),
+  resourceType: z.enum(['costCenter', 'costCenter_deleted'])
 });
 
+// eslint-disable-next-line @rushstack/typedef-var
+export const CostCenterParser = CostCenterWithResourceTypeParser.omit({ resourceType: true });
+
+export type CostCenterWithResourceType = z.infer<typeof CostCenterWithResourceTypeParser>;
 export type CostCenter = z.infer<typeof CostCenterParser>;

--- a/workbench-core/accounts/src/services/accountService.test.ts
+++ b/workbench-core/accounts/src/services/accountService.test.ts
@@ -17,6 +17,7 @@ import { marshall } from '@aws-sdk/util-dynamodb';
 import { JSONValue, resourceTypeToKey } from '@aws/workbench-core-base';
 import DynamoDBService from '@aws/workbench-core-base/lib/aws/helpers/dynamoDB/dynamoDBService';
 import { AwsStub, mockClient } from 'aws-sdk-client-mock';
+import { CostCenterStatus } from '../constants/costCenterStatus';
 import { Account, AccountParser } from '../models/accounts/account';
 import { CostCenter } from '../models/costCenters/costCenter';
 import AccountService from './accountService';
@@ -350,7 +351,8 @@ describe('AccountService', () => {
             pk: costCenterPK,
             sk: costCenterPK,
             id: expectedCCId,
-            name: 'cost center 1'
+            name: 'cost center 1',
+            status: CostCenterStatus.AVAILABLE
           };
         });
 

--- a/workbench-core/accounts/src/services/costCenterService.test.ts
+++ b/workbench-core/accounts/src/services/costCenterService.test.ts
@@ -27,7 +27,12 @@ describe('CostCenterService', () => {
   const accountId = 'acc-someId';
   const ddbMock = mockClient(DynamoDBClient);
   const mockDateObject = new Date('2021-02-26T22:42:16.652Z');
-  type CostCenterJson = Omit<CostCenter, 'accountId'> & { pk: string; sk: string; dependency: string };
+  type CostCenterJson = Omit<CostCenter, 'accountId'> & {
+    pk: string;
+    sk: string;
+    dependency: string;
+    resourceType: string;
+  };
 
   beforeEach(() => {
     jest.resetModules();
@@ -97,7 +102,8 @@ describe('CostCenterService', () => {
             Item: marshall(
               {
                 ...expectedCostCenter,
-                dependency: accountId
+                dependency: accountId,
+                resourceType: 'costCenter'
               },
               {
                 removeUndefinedValues: true
@@ -121,6 +127,23 @@ describe('CostCenterService', () => {
         test('it throws an error', async () => {
           await expect(costCenterService.getCostCenter(costCenterId)).rejects.toThrow(
             `Could not find cost center ${costCenterId}`
+          );
+        });
+      });
+
+      describe('and cost center has been deleted', () => {
+        beforeEach(() => {
+          ddbMock.on(GetItemCommand).resolves({
+            Item: marshall({
+              ...expectedCostCenter,
+              resourceType: 'costCenter_deleted'
+            })
+          });
+        });
+
+        test('it throws an error', async () => {
+          await expect(costCenterService.getCostCenter(costCenterId)).rejects.toThrow(
+            `Cost center ${costCenterId} was deleted`
           );
         });
       });
@@ -149,7 +172,8 @@ describe('CostCenterService', () => {
         hostingAccountHandlerRoleArn: account.hostingAccountHandlerRoleArn,
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
-        updatedAt: mockDateObject.toISOString()
+        updatedAt: mockDateObject.toISOString(),
+        resourceType: 'costCenter'
       };
       expectedCostCenter = {
         ...costCenterJson,
@@ -266,7 +290,9 @@ describe('CostCenterService', () => {
             accountId: accountId,
             id: costCenterId
           };
-          ddbMock.on(UpdateItemCommand).resolves({ Attributes: marshall(costCenter) });
+          ddbMock
+            .on(UpdateItemCommand)
+            .resolves({ Attributes: marshall({ ...costCenter, resourceType: 'costCenter' }) });
         });
 
         test('it returns a CostCenter object with the associated Account metadata', async () => {
@@ -315,7 +341,8 @@ describe('CostCenterService', () => {
         hostingAccountHandlerRoleArn: account.hostingAccountHandlerRoleArn,
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
-        updatedAt: mockDateObject.toISOString()
+        updatedAt: mockDateObject.toISOString(),
+        resourceType: 'costCenter'
       };
       // Mock getting projects associated with cost center
       ddbMock.on(QueryCommand).resolves({
@@ -400,7 +427,8 @@ describe('CostCenterService', () => {
         hostingAccountHandlerRoleArn: account.hostingAccountHandlerRoleArn,
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
-        updatedAt: mockDateObject.toISOString()
+        updatedAt: mockDateObject.toISOString(),
+        resourceType: 'costCenter'
       };
       ddbMock.on(GetItemCommand).resolves({ Item: marshall(costCenterJson) });
     });
@@ -474,7 +502,8 @@ describe('CostCenterService', () => {
         hostingAccountHandlerRoleArn: account.hostingAccountHandlerRoleArn,
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
-        updatedAt: mockDateObject.toISOString()
+        updatedAt: mockDateObject.toISOString(),
+        resourceType: 'costCenter'
       };
       // Mock getting projects associated with cost center
       ddbMock.on(QueryCommand).resolves({
@@ -559,7 +588,8 @@ describe('CostCenterService', () => {
         hostingAccountHandlerRoleArn: account.hostingAccountHandlerRoleArn,
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
-        updatedAt: mockDateObject.toISOString()
+        updatedAt: mockDateObject.toISOString(),
+        resourceType: 'costCenter'
       };
       ddbMock.on(GetItemCommand).resolves({ Item: marshall(costCenterJson) });
     });

--- a/workbench-core/accounts/src/services/costCenterService.test.ts
+++ b/workbench-core/accounts/src/services/costCenterService.test.ts
@@ -11,6 +11,7 @@ import { resourceTypeToKey } from '@aws/workbench-core-base';
 import DynamoDBService from '@aws/workbench-core-base/lib/aws/helpers/dynamoDB/dynamoDBService';
 import * as Boom from '@hapi/boom';
 import { mockClient } from 'aws-sdk-client-mock';
+import { CostCenterStatus } from '../constants/costCenterStatus';
 import { Account, AccountParser } from '../models/accounts/account';
 import { CostCenter, CostCenterParser } from '../models/costCenters/costCenter';
 import CreateCostCenterRequest from '../models/costCenters/createCostCenterRequest';
@@ -31,7 +32,6 @@ describe('CostCenterService', () => {
     pk: string;
     sk: string;
     dependency: string;
-    resourceType: string;
   };
 
   beforeEach(() => {
@@ -92,7 +92,8 @@ describe('CostCenterService', () => {
           accountId: accountId,
           dependency: accountId,
           description: 'a description',
-          id: costCenterId
+          id: costCenterId,
+          status: CostCenterStatus.AVAILABLE
         };
       });
 
@@ -130,23 +131,6 @@ describe('CostCenterService', () => {
           );
         });
       });
-
-      describe('and cost center has been deleted', () => {
-        beforeEach(() => {
-          ddbMock.on(GetItemCommand).resolves({
-            Item: marshall({
-              ...expectedCostCenter,
-              resourceType: 'costCenter_deleted'
-            })
-          });
-        });
-
-        test('it throws an error', async () => {
-          await expect(costCenterService.getCostCenter(costCenterId)).rejects.toThrow(
-            `Cost center ${costCenterId} was deleted`
-          );
-        });
-      });
     });
   });
 
@@ -173,7 +157,7 @@ describe('CostCenterService', () => {
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
         updatedAt: mockDateObject.toISOString(),
-        resourceType: 'costCenter'
+        status: CostCenterStatus.AVAILABLE
       };
       expectedCostCenter = {
         ...costCenterJson,
@@ -288,7 +272,8 @@ describe('CostCenterService', () => {
             description: createCostCenter.description,
             dependency: createCostCenter.accountId,
             accountId: accountId,
-            id: costCenterId
+            id: costCenterId,
+            status: CostCenterStatus.AVAILABLE
           };
           ddbMock
             .on(UpdateItemCommand)
@@ -342,7 +327,7 @@ describe('CostCenterService', () => {
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
         updatedAt: mockDateObject.toISOString(),
-        resourceType: 'costCenter'
+        status: CostCenterStatus.AVAILABLE
       };
       // Mock getting projects associated with cost center
       ddbMock.on(QueryCommand).resolves({
@@ -428,7 +413,7 @@ describe('CostCenterService', () => {
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
         updatedAt: mockDateObject.toISOString(),
-        resourceType: 'costCenter'
+        status: CostCenterStatus.AVAILABLE
       };
       ddbMock.on(GetItemCommand).resolves({ Item: marshall(costCenterJson) });
     });
@@ -459,7 +444,8 @@ describe('CostCenterService', () => {
           hostingAccountHandlerRoleArn: '',
           awsAccountId: 'awsAccountId',
           createdAt: '2021-02-26T22:42:16.652Z',
-          updatedAt: '2021-02-26T22:42:16.652Z'
+          updatedAt: '2021-02-26T22:42:16.652Z',
+          status: CostCenterStatus.AVAILABLE
         });
       });
     });
@@ -503,7 +489,7 @@ describe('CostCenterService', () => {
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
         updatedAt: mockDateObject.toISOString(),
-        resourceType: 'costCenter'
+        status: CostCenterStatus.AVAILABLE
       };
       // Mock getting projects associated with cost center
       ddbMock.on(QueryCommand).resolves({
@@ -589,7 +575,7 @@ describe('CostCenterService', () => {
         awsAccountId: account.awsAccountId,
         createdAt: mockDateObject.toISOString(),
         updatedAt: mockDateObject.toISOString(),
-        resourceType: 'costCenter'
+        status: CostCenterStatus.AVAILABLE
       };
       ddbMock.on(GetItemCommand).resolves({ Item: marshall(costCenterJson) });
     });
@@ -620,7 +606,8 @@ describe('CostCenterService', () => {
           hostingAccountHandlerRoleArn: '',
           awsAccountId: 'awsAccountId',
           createdAt: '2021-02-26T22:42:16.652Z',
-          updatedAt: '2021-02-26T22:42:16.652Z'
+          updatedAt: '2021-02-26T22:42:16.652Z',
+          status: CostCenterStatus.AVAILABLE
         });
       });
     });

--- a/workbench-core/accounts/src/services/costCenterService.ts
+++ b/workbench-core/accounts/src/services/costCenterService.ts
@@ -17,13 +17,9 @@ import {
 } from '@aws/workbench-core-base';
 import DynamoDBService from '@aws/workbench-core-base/lib/aws/helpers/dynamoDB/dynamoDBService';
 import * as Boom from '@hapi/boom';
-import _ from 'lodash';
+import { CostCenterStatus } from '../constants/costCenterStatus';
 import { Account } from '../models/accounts/account';
-import {
-  CostCenter,
-  CostCenterWithResourceType,
-  CostCenterWithResourceTypeParser
-} from '../models/costCenters/costCenter';
+import { CostCenter, CostCenterParser } from '../models/costCenters/costCenter';
 import CreateCostCenterRequest from '../models/costCenters/createCostCenterRequest';
 import { DeleteCostCenterRequest } from '../models/costCenters/deleteCostCenterRequest';
 import { ListCostCentersRequest } from '../models/costCenters/listCostCentersRequest';
@@ -55,7 +51,7 @@ export default class CostCenterService {
       await this._dynamoDbService.updateExecuteAndFormat({
         key: buildDynamoDBPkSk(request.id, resourceTypeToKey.costCenter),
         params: {
-          item: { resourceType: `${this._resourceType}_deleted` }
+          item: { status: CostCenterStatus.DELETED }
         }
       });
     } catch (e) {
@@ -70,6 +66,7 @@ export default class CostCenterService {
    */
   public async updateCostCenter(request: UpdateCostCenterRequest): Promise<CostCenter> {
     await this.getCostCenter(request.id);
+
     const currentDate = new Date().toISOString();
     const updatedCostCenter = {
       name: request.name,
@@ -88,7 +85,7 @@ export default class CostCenterService {
       throw Boom.internal(`Unable to update CostCenter with params ${JSON.stringify(request)}`);
     }
     if (response.Attributes) {
-      return _.omit(this._mapDDBItemToCostCenter(response.Attributes), 'resourceType');
+      return this._mapDDBItemToCostCenter(response.Attributes);
     }
     throw Boom.internal(`Unable to update CostCenter with params ${JSON.stringify(request)}`);
   }
@@ -113,7 +110,7 @@ export default class CostCenterService {
 
     return {
       data: response.data.map((item) => {
-        return _.omit(this._mapDDBItemToCostCenter(item), 'resourceType');
+        return this._mapDDBItemToCostCenter(item);
       }),
       paginationToken: response.paginationToken
     };
@@ -129,13 +126,7 @@ export default class CostCenterService {
       throw Boom.notFound(`Could not find cost center ${costCenterId}`);
     }
 
-    const costCenter = this._mapDDBItemToCostCenter(response.Item);
-
-    if (costCenter.resourceType.endsWith('_deleted')) {
-      throw Boom.notFound(`Cost center ${costCenterId} was deleted`);
-    }
-
-    return _.omit(costCenter, 'resourceType');
+    return this._mapDDBItemToCostCenter(response.Item);
   }
 
   public async create(request: CreateCostCenterRequest): Promise<CostCenter> {
@@ -158,7 +149,8 @@ export default class CostCenterService {
       subnetId: account.subnetId!,
       vpcId: account.vpcId!,
       environmentInstanceFiles: account.environmentInstanceFiles!,
-      externalId: account.externalId
+      externalId: account.externalId,
+      status: CostCenterStatus.AVAILABLE
     };
 
     const dynamoItem: { [key: string]: string } = {
@@ -178,15 +170,15 @@ export default class CostCenterService {
       }
     });
     if (response.Attributes) {
-      return _.omit(this._mapDDBItemToCostCenter(response.Attributes), 'resourceType');
+      return this._mapDDBItemToCostCenter(response.Attributes);
     }
     throw Boom.internal(`Unable to create CostCenter with params ${JSON.stringify(request)}`);
   }
 
-  private _mapDDBItemToCostCenter(item: { [key: string]: unknown }): CostCenterWithResourceType {
+  private _mapDDBItemToCostCenter(item: { [key: string]: unknown }): CostCenter {
     const costCenter: { [key: string]: unknown } = { ...item, accountId: item.dependency };
     // parse will remove pk and sk from the DDB item
-    return CostCenterWithResourceTypeParser.parse(costCenter);
+    return CostCenterParser.parse(costCenter);
   }
 
   private async _getAccount(accountId: string): Promise<Account> {

--- a/workbench-core/accounts/src/services/projectService.test.ts
+++ b/workbench-core/accounts/src/services/projectService.test.ts
@@ -36,6 +36,7 @@ import Query from '@aws/workbench-core-base/lib/aws/helpers/dynamoDB/query';
 import Updater from '@aws/workbench-core-base/lib/aws/helpers/dynamoDB/updater';
 import * as Boom from '@hapi/boom';
 import { mockClient } from 'aws-sdk-client-mock';
+import { CostCenterStatus } from '../constants/costCenterStatus';
 import { ProjectStatus } from '../constants/projectStatus';
 import { DeleteProjectRequest } from '../models/projects/deleteProjectRequest';
 import { Project } from '../models/projects/project';
@@ -200,7 +201,7 @@ describe('ProjectService', () => {
     subnetId: 'subnet-07f475d83291a3603',
     updatedAt: timestamp,
     vpcId: 'vpc-0b0bc7ae01d82e7b3',
-    resourceType: 'costCenter'
+    status: CostCenterStatus.AVAILABLE
   };
 
   const noUserGroupsFunction = jest.fn((request: GetUserGroupsRequest): Promise<GetUserGroupsResponse> => {
@@ -1483,7 +1484,7 @@ describe('ProjectService', () => {
 
       // mock getCostCenter call
       const getCostCenterGetItemResponse: GetItemCommandOutput = {
-        Item: marshall({ ...costCenterItem, resourceType: 'costCenter_deleted' }),
+        Item: marshall({ ...costCenterItem, status: CostCenterStatus.DELETED }),
         $metadata: {}
       };
       ddbMock

--- a/workbench-core/accounts/src/services/projectService.ts
+++ b/workbench-core/accounts/src/services/projectService.ts
@@ -27,6 +27,7 @@ import {
   DynamoDBService
 } from '@aws/workbench-core-base';
 import * as Boom from '@hapi/boom';
+import { CostCenterStatus } from '../constants/costCenterStatus';
 import { ProjectStatus } from '../constants/projectStatus';
 import { CostCenter } from '../models/costCenters/costCenter';
 import { CreateProjectRequest } from '../models/projects/createProjectRequest';
@@ -442,11 +443,18 @@ export default class ProjectService {
   }
 
   private async _getCostCenter(costCenterId: string): Promise<CostCenter> {
+    let costCenter: CostCenter;
     try {
-      return this._costCenterService.getCostCenter(costCenterId);
+      costCenter = await this._costCenterService.getCostCenter(costCenterId);
     } catch (e) {
       throw Boom.badRequest(`Could not find cost center ${costCenterId}`);
     }
+
+    if (costCenter.status !== CostCenterStatus.AVAILABLE) {
+      throw Boom.badRequest(`Cost center ${costCenterId} was deleted`);
+    }
+
+    return costCenter;
   }
 
   /**


### PR DESCRIPTION
Issue #, if available: GALI-2282

Description of changes:

* new `status` field returned from cost center API with two possible values `AVAILABLE` and `DELETED`
* each cost center starts with `AVAILABLE` and after soft deleting it switches to `DELETED`
* new check in project creation testing for `status === `AVAILABLE`


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.