### PR TITLE
test(accounts): add a test to verify structure of awsAccountTemplateU…

### DIFF
--- a/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/awsAccountTemplateUrls.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/awsAccounts/awsAccountTemplateUrls.test.ts
@@ -1,0 +1,42 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import _ from 'lodash';
+import ClientSession from '../../../support/clientSession';
+import Setup from '../../../support/setup';
+
+describe('awsAccountTemplateUrls tests', () => {
+  const mockExternalId = 'workbench-integration-test';
+  const setup: Setup = new Setup();
+  let adminSession: ClientSession;
+
+  beforeEach(() => {
+    expect.hasAssertions();
+  });
+
+  beforeAll(async () => {
+    adminSession = await setup.getDefaultAdminSession();
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  it('returns all six expected URLs when called.', async () => {
+    const response = await adminSession.resources.accounts.getHostingAccountTemplate(mockExternalId);
+    const urls = response.data;
+
+    expect(urls).toBeDefined();
+    const onboardUrls = _.get(urls, 'onboard-account');
+    expect(onboardUrls.createUrl).toBeTruthy();
+    expect(onboardUrls.updateUrl).toBeTruthy();
+    const byonUrls = _.get(urls, 'onboard-account-byon');
+    expect(byonUrls.createUrl).toBeTruthy();
+    expect(byonUrls.updateUrl).toBeTruthy();
+    const tgwUrls = _.get(urls, 'onboard-account-tgw');
+    expect(tgwUrls.createUrl).toBeTruthy();
+    expect(tgwUrls.updateUrl).toBeTruthy();
+  });
+});


### PR DESCRIPTION
…rls API response

Issue #, if available:

Description of changes:
This is just a test to verify the structure of the response to `awsAccountTemplateUrls` API. I have yet to devise a test to ensure the presigned URL is working as expected however that has been manually validated for all three templates.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?
* [X] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.