### PR TITLE
fix: datasets integ test fix

### DIFF
--- a/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
@@ -142,13 +142,13 @@ describe('multiStep dataset integration test', () => {
     );
     const expected: DataSetPermission[] = [
       {
-        accessLevel: 'read-write',
-        identity: `${projectId}#Researcher`,
+        accessLevel: 'read-only',
+        identity: `${unassociatedProject.id}#ProjectAdmin`,
         identityType: 'GROUP'
       },
       {
-        accessLevel: 'read-only',
-        identity: `${unassociatedProject.id}#ProjectAdmin`,
+        accessLevel: 'read-write',
+        identity: `${projectId}#Researcher`,
         identityType: 'GROUP'
       }
     ];


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- fixed ordering of dataset permissions in datasets multistep integ test

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.