### PR TITLE
feat: project as a Boundary integ test and GetDataset route

### DIFF
--- a/common/changes/@aws/swb-app/kevpark-paab-happy-path_2023-02-25-05-01.json
+++ b/common/changes/@aws/swb-app/kevpark-paab-happy-path_2023-02-25-05-01.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "Add GetDataset route",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/solutions/swb-app/src/dataSetRoutes.ts
+++ b/solutions/swb-app/src/dataSetRoutes.ts
@@ -156,6 +156,17 @@ export function setUpDSRoutes(router: Router, dataSetService: DataSetPlugin): vo
     })
   );
 
+  // Get DataSet
+  router.get(
+    '/datasets/:datasetId',
+    wrapAsync(async (req: Request, res: Response) => {
+      const authenticatedUser = validateAndParse<AuthenticatedUser>(AuthenticatedUserParser, res.locals.user);
+
+      const response = await dataSetService.getDataSet(req.params.datasetId, authenticatedUser);
+      res.send(response);
+    })
+  );
+
   router.put(
     '/projects/:projectId/datasets/:datasetId/relationships',
     wrapAsync(async (req: Request, res: Response) => {

--- a/solutions/swb-reference/integration-tests/support/models/environmentTypeConfigs.ts
+++ b/solutions/swb-reference/integration-tests/support/models/environmentTypeConfigs.ts
@@ -1,0 +1,9 @@
+export interface EnvironmentTypeConfigItemResponse {
+  id: string;
+}
+
+export interface ListETCsResponse {
+  data: {
+    data: EnvironmentTypeConfigItemResponse[];
+  };
+}

--- a/solutions/swb-reference/integration-tests/support/models/projects.ts
+++ b/solutions/swb-reference/integration-tests/support/models/projects.ts
@@ -1,0 +1,12 @@
+import { ProjectStatus } from '@aws/workbench-core-accounts/lib/constants/projectStatus';
+
+export interface ProjectItemResponse {
+  id: string;
+  status: ProjectStatus;
+}
+
+export interface ListProjectsResponse {
+  data: {
+    data: ProjectItemResponse[];
+  };
+}

--- a/solutions/swb-reference/integration-tests/support/resources/environmentTypeConfigs/environmentTypeConfig.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/environmentTypeConfigs/environmentTypeConfig.ts
@@ -3,6 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 import ClientSession from '../../clientSession';
+import { ListProjectsResponse } from '../../models/projects';
 import { DEFLAKE_DELAY_IN_MILLISECONDS } from '../../utils/constants';
 import { sleep } from '../../utils/utilities';
 import Resource from '../base/resource';
@@ -34,6 +35,23 @@ export default class EnvironmentTypeConfig extends Resource {
   protected async cleanup(): Promise<void> {
     const defAdminSession = await this._setup.getDefaultAdminSession();
     await sleep(DEFLAKE_DELAY_IN_MILLISECONDS); //Avoid throttling when terminating multiple environment type configs
+    const { data: associatedProjects }: ListProjectsResponse =
+      await defAdminSession.resources.environmentTypes
+        .environmentType(this._parentId)
+        .configurations()
+        .environmentTypeConfig(this._id)
+        .projects()
+        .get();
+    associatedProjects.data?.forEach(async (project) => {
+      await defAdminSession.resources.projects
+        .project(project.id)
+        .environmentTypes()
+        .environmentType(this._parentId)
+        .configurations()
+        .environmentTypeConfig(this._id)
+        .disassociate();
+    });
+
     await defAdminSession.resources.environmentTypes
       .environmentType(this._parentId)
       .configurations()

--- a/solutions/swb-reference/integration-tests/support/resources/environments/environment.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/environments/environment.ts
@@ -63,7 +63,7 @@ export default class Environment extends Resource {
         ENVIRONMENT_START_MAX_WAITING_SECONDS
       );
 
-      if (!['STOPPED'].includes(envStatus)) {
+      if (!['STOPPED', 'TERMINATING'].includes(envStatus)) {
         console.log(
           `Environment must be stopped to terminate. Currently in state ${envStatus}. Stopping environment ${this._id}.`
         );

--- a/solutions/swb-reference/integration-tests/support/utils/constants.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/constants.ts
@@ -5,8 +5,8 @@
 //Average start waiting time is 5 minutes, setting start max waiting to 10 minutes
 export const ENVIRONMENT_START_MAX_WAITING_SECONDS: number = 600;
 
-//Average start waiting time is 2 minutes, setting start max waiting to 4 minutes
-export const ENVIRONMENT_STOP_MAX_WAITING_SECONDS: number = 240;
+//Average start waiting time is 2 minutes, setting start max waiting to 5 minutes
+export const ENVIRONMENT_STOP_MAX_WAITING_SECONDS: number = 300;
 
 //Average start waiting time is 1:30 minutes, setting start max waiting to 3 minutes
 export const ENVIRONMENT_TERMINATE_MAX_WAITING_SECONDS: number = 180;

--- a/solutions/swb-reference/integration-tests/tests/multiStep/paab.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/paab.test.ts
@@ -1,0 +1,452 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import { CreateDataSetRequestParser } from '@aws/swb-app/lib/dataSets/createDataSetRequestParser';
+import { getProjectAdminRole, getResearcherRole } from '../../../src/utils/roleUtils';
+import ClientSession from '../../support/clientSession';
+import { PaabHelper } from '../../support/complex/paabHelper';
+import { ListEnvironmentResponse } from '../../support/models/environments';
+import { ListETCsResponse } from '../../support/models/environmentTypeConfigs';
+import { ListProjectsResponse } from '../../support/models/projects';
+import Setup from '../../support/setup';
+import {
+  ENVIRONMENT_START_MAX_WAITING_SECONDS,
+  ENVIRONMENT_STOP_MAX_WAITING_SECONDS
+} from '../../support/utils/constants';
+import HttpError from '../../support/utils/HttpError';
+import RandomTextGenerator from '../../support/utils/randomTextGenerator';
+import { envUuidRegExp } from '../../support/utils/regExpressions';
+import { checkHttpError, poll } from '../../support/utils/utilities';
+
+jest.retryTimes(0);
+
+describe('multiStep environment test', () => {
+  const paabHelper: PaabHelper = new PaabHelper();
+  const setup: Setup = new Setup();
+  const etId: string = setup.getSettings().get('envTypeId');
+  const unauthorizedHttpError = new HttpError(403, { error: 'User is not authorized' });
+  let adminSession: ClientSession;
+  let pa1Session: ClientSession;
+  let pa2Session: ClientSession;
+  let project1Id: string;
+  let project2Id: string;
+  let rs1Session: ClientSession;
+
+  beforeAll(async () => {
+    ({ adminSession, pa1Session, pa2Session, project1Id, project2Id, rs1Session } =
+      await paabHelper.createResources());
+  });
+
+  afterAll(async () => {
+    await paabHelper.cleanup();
+  });
+
+  test('test project as a boundary against all resources', async () => {
+    console.log('Creating Environment Type Configs for Projects...');
+    const { data: etc1 } = await adminSession.resources.environmentTypes
+      .environmentType(etId)
+      .configurations()
+      .create();
+    const { data: etc2 } = await adminSession.resources.environmentTypes
+      .environmentType(etId)
+      .configurations()
+      .create();
+
+    console.log('Associating Environment Type Configs to Projects...');
+    await adminSession.resources.projects
+      .project(project1Id)
+      .environmentTypes()
+      .environmentType(etId)
+      .configurations()
+      .environmentTypeConfig(etc1.id)
+      .associate();
+    await adminSession.resources.projects
+      .project(project2Id)
+      .environmentTypes()
+      .environmentType(etId)
+      .configurations()
+      .environmentTypeConfig(etc2.id)
+      .associate();
+
+    console.log('Creating Environment1 for Project1...');
+    const { data: env1 } = await pa1Session.resources.projects.project(project1Id).environments().create();
+
+    console.log('Creating Environment2 for Project2...');
+    const { data: env2 } = await pa2Session.resources.projects.project(project2Id).environments().create();
+
+    console.log('Creating Dataset1 for Project1...');
+    const randomTextGenerator = new RandomTextGenerator(setup.getSettings().get('runId'));
+    const datasetName = randomTextGenerator.getFakeText('paab-test');
+    const dataSetBody = CreateDataSetRequestParser.parse({
+      storageName: setup.getSettings().get('DataSetsBucketName'),
+      awsAccountId: setup.getSettings().get('mainAccountId'),
+      path: datasetName, // using same name to help potential troubleshooting
+      name: datasetName,
+      region: setup.getSettings().get('awsRegion'),
+      owner: getProjectAdminRole(project1Id),
+      ownerType: 'GROUP',
+      type: 'internal',
+      permissions: [
+        {
+          identity: getResearcherRole(project1Id),
+          identityType: 'GROUP',
+          accessLevel: 'read-write'
+        }
+      ]
+    });
+    const { data: ds1 } = await pa1Session.resources.projects
+      .project(project1Id)
+      .dataSets()
+      .create(dataSetBody, false);
+
+    console.log('Verifying PA1 CANNOT see Project2...');
+    // List Projects
+    const { data: listProjects1 }: ListProjectsResponse = await pa1Session.resources.projects.get();
+    expect(listProjects1.data.filter((proj) => proj.id === project2Id).length).toEqual(0);
+
+    // Get Projects
+    try {
+      await pa1Session.resources.projects.project(project2Id).get();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+
+    console.log('Verify PA1 CANNOT see ETC2...');
+    // Get ETC
+    try {
+      await pa1Session.resources.projects
+        .project(project2Id)
+        .environmentTypes()
+        .environmentType(etId)
+        .configurations()
+        .environmentTypeConfig(etc2.id)
+        .get();
+    } catch (e) {
+      checkHttpError(e, unauthorizedHttpError);
+    }
+    // List ETCs for Project
+    const { data: listEtcs1 }: ListETCsResponse = await pa1Session.resources.projects
+      .project(project1Id)
+      .environmentTypes()
+      .environmentType(etId)
+      .configurations()
+      .get();
+    expect(listEtcs1.data.filter((etc) => etc.id === etc2.id).length).toEqual(0);
+
+    console.log('Verifying PA1 CANNOT create an Environment in Project2...');
+    try {
+      await pa1Session.resources.projects.project(project2Id).environments().create();
+    } catch (e) {
+      checkHttpError(e, unauthorizedHttpError);
+    }
+
+    console.log('Verifying PA2 CANNOT see Project1...');
+    // List Projects
+    const { data: listProjects2 }: ListProjectsResponse = await pa2Session.resources.projects.get();
+    expect(listProjects2.data.filter((proj) => proj.id === project1Id).length).toEqual(0);
+    // Get Projects
+    try {
+      await pa2Session.resources.projects.project(project1Id).get();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+
+    console.log('Verifying PA2 CANNOT see Dataset1...');
+    // List Datasets for Project
+    // const { data: pa2Datasets }: ListDatasetsResponse = await pa2Session.resources.projects
+    //   .project(project2Id)
+    //   .dataSets()
+    //   .get()
+    // expect(
+    //   pa2Datasets.data.filter((ds) => ds.id === ds1.id).length
+    // ).toEqual(0);
+    // Get Dataset
+    try {
+      await pa2Session.resources.projects.project(project1Id).dataSets().dataset(ds1.id).get();
+    } catch (e) {
+      checkHttpError(e, unauthorizedHttpError);
+    }
+
+    console.log('Verifying PA2 cannot upload files to Dataset1...');
+    const fileName: string = 'file.txt';
+    try {
+      await pa1Session.resources.projects
+        .project(project1Id)
+        .dataSets()
+        .dataset(ds1.id)
+        .getFileUploadUrls(fileName);
+    } catch (e) {
+      checkHttpError(e, unauthorizedHttpError);
+    }
+
+    console.log('Verifying PA2 CANNOT see Environment1');
+    // List Environments for Project
+    const { data: pa2Environments }: ListEnvironmentResponse = await pa2Session.resources.projects
+      .project(project2Id)
+      .environments()
+      .listProjectEnvironments();
+    expect(pa2Environments.data.filter((env) => env.id === env1.id).length).toEqual(0);
+    // Get Environment
+    try {
+      await pa2Session.resources.projects.project(project1Id).environments().environment(env1.id).get();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+
+    console.log('Verifying PA2 CANNOT call any Environment APIs against Environment1');
+    // Connect
+    try {
+      await pa2Session.resources.projects.project(project1Id).environments().environment(env1.id).connect();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+    // Start
+    try {
+      await pa2Session.resources.projects.project(project1Id).environments().environment(env1.id).start();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+    // Stop
+    try {
+      await pa2Session.resources.projects.project(project1Id).environments().environment(env1.id).stop();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+    // Terminate
+    try {
+      await pa2Session.resources.projects.project(project1Id).environments().environment(env1.id).terminate();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+
+    console.log('Verifying Researcher1 CANNOT see Project2...');
+    // List Projects
+    const { data: researcherProjects }: ListProjectsResponse = await rs1Session.resources.projects.get();
+    expect(researcherProjects.data.filter((proj) => proj.id === project2Id).length).toEqual(0);
+    // Get Projects
+    try {
+      await rs1Session.resources.projects.project(project2Id).get();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+
+    console.log('Verifying Researcher1 CANNOT see Environment2...');
+    // List Environments for Project
+    const { data: researcherEnvironments }: ListEnvironmentResponse = await rs1Session.resources.projects
+      .project(project1Id)
+      .environments()
+      .listProjectEnvironments();
+    expect(researcherEnvironments.data.filter((env) => env.id === env2.id).length).toEqual(0);
+    // Get Environment
+    try {
+      await rs1Session.resources.projects.project(project2Id).environments().environment(env2.id).get();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+
+    console.log('Verifying Researcher1 CANNOT call any Environment APIs against Environment2');
+    // Connect
+    try {
+      await rs1Session.resources.projects.project(project2Id).environments().environment(env2.id).connect();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+    // Start
+    try {
+      await rs1Session.resources.projects.project(project2Id).environments().environment(env2.id).start();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+    // Stop
+    try {
+      await rs1Session.resources.projects.project(project2Id).environments().environment(env2.id).stop();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+    // Terminate
+    try {
+      await rs1Session.resources.projects.project(project2Id).environments().environment(env2.id).terminate();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+
+    console.log('Verifying Researcher1 CANNOT see ETC2...');
+    // Get ETC
+    try {
+      await rs1Session.resources.projects
+        .project(project2Id)
+        .environmentTypes()
+        .environmentType(etId)
+        .configurations()
+        .environmentTypeConfig(etc2.id)
+        .get();
+    } catch (e) {
+      checkHttpError(e, unauthorizedHttpError);
+    }
+    // List ETCs for Project
+    const { data: rs1Etcs }: ListETCsResponse = await rs1Session.resources.projects
+      .project(project1Id)
+      .environmentTypes()
+      .environmentType(etId)
+      .configurations()
+      .get();
+    expect(rs1Etcs.data.filter((etc) => etc.id === etc2.id).length).toEqual(0);
+
+    console.log('Verifying Researcher1 CANNOT create Environment in Project2...');
+    try {
+      await rs1Session.resources.projects.project(project2Id).environments().create();
+    } catch (e) {
+      checkHttpError(e, unauthorizedHttpError);
+    }
+
+    console.log('Verifying ITAdmin CAN see both environments...');
+    // List Environments
+    const { data: allEnvironments }: ListEnvironmentResponse =
+      await adminSession.resources.environments.get();
+    expect(allEnvironments.data.filter((env) => env.id === env1.id).length).toEqual(1);
+    expect(allEnvironments.data.filter((env) => env.id === env2.id).length).toEqual(1);
+    // Get Environment
+    const { data: adminEnv1 } = await adminSession.resources.projects
+      .project(project1Id)
+      .environments()
+      .environment(env1.id)
+      .get();
+    expect(adminEnv1.id).toEqual(env1.id);
+    const { data: adminEnv2 } = await adminSession.resources.projects
+      .project(project2Id)
+      .environments()
+      .environment(env2.id)
+      .get();
+    expect(adminEnv2.id).toEqual(env2.id);
+
+    console.log('Verifying ITAdmin CANNOT upload file to Dataset1...');
+    try {
+      await adminSession.resources.projects
+        .project(project1Id)
+        .dataSets()
+        .dataset(ds1.id)
+        .getFileUploadUrls(fileName);
+    } catch (e) {
+      checkHttpError(e, unauthorizedHttpError);
+    }
+
+    console.log('Verifying ITAdmin CANNOT connect to Environment1...');
+    try {
+      await adminSession.resources.projects.project(project2Id).environments().environment(env2.id).connect();
+    } catch (err) {
+      checkHttpError(err, unauthorizedHttpError);
+    }
+
+    console.log('Verifying Researcher1 CAN call all Environment APIs against Environment1...');
+    // Start (expecting this to fail since the state is not STOPPED, but not due to unauthorized access)
+    try {
+      await rs1Session.resources.projects.project(project1Id).environments().environment(env1.id).start();
+    } catch (e) {
+      expect(e).not.toEqual(unauthorizedHttpError);
+    }
+    await _waitForEnvironmentToReachState(
+      rs1Session,
+      project1Id,
+      env1.id,
+      'PENDING',
+      'COMPLETED',
+      ENVIRONMENT_START_MAX_WAITING_SECONDS
+    );
+    // Connect
+    await rs1Session.resources.projects.project(project1Id).environments().environment(env1.id).connect();
+    // Stop
+    await rs1Session.resources.projects.project(project1Id).environments().environment(env1.id).stop();
+
+    console.log('Verifying ITAdmin can call all other Environment APIs against Environment1...');
+    // Start (expecting this to fail since the state is not STOPPED, but not due to unauthorized access)
+    try {
+      await adminSession.resources.projects.project(project2Id).environments().environment(env2.id).start();
+    } catch (e) {
+      expect(e).not.toEqual(unauthorizedHttpError);
+    }
+    await _waitForEnvironmentToReachState(
+      adminSession,
+      project2Id,
+      env2.id,
+      'PENDING',
+      'COMPLETED',
+      ENVIRONMENT_START_MAX_WAITING_SECONDS
+    );
+    // Stop
+    await adminSession.resources.projects.project(project2Id).environments().environment(env2.id).stop();
+
+    console.log('Verifying Researcher1 CAN see Dataset1...');
+    const { data: researcherDS } = await rs1Session.resources.projects
+      .project(project1Id)
+      .dataSets()
+      .dataset(ds1.id)
+      .get();
+    expect(researcherDS.id).toEqual(ds1.id);
+
+    console.log('Verifying Researcher1 can terminate environment1...');
+    await _waitForEnvironmentToReachState(
+      rs1Session,
+      project1Id,
+      env1.id,
+      'STOPPING',
+      'STOPPED',
+      ENVIRONMENT_STOP_MAX_WAITING_SECONDS
+    );
+    await rs1Session.resources.projects.project(project1Id).environments().environment(env1.id).terminate();
+
+    console.log('Verifying ITAdmin can terminate environment2...');
+    await _waitForEnvironmentToReachState(
+      adminSession,
+      project2Id,
+      env2.id,
+      'STOPPING',
+      'STOPPED',
+      ENVIRONMENT_STOP_MAX_WAITING_SECONDS
+    );
+    await adminSession.resources.projects.project(project2Id).environments().environment(env2.id).terminate();
+
+    console.log('Disassociating Environment Type Configs from Projects...');
+    await adminSession.resources.projects
+      .project(project1Id)
+      .environmentTypes()
+      .environmentType(etId)
+      .configurations()
+      .environmentTypeConfig(etc1.id)
+      .disassociate();
+    await adminSession.resources.projects
+      .project(project2Id)
+      .environmentTypes()
+      .environmentType(etId)
+      .configurations()
+      .environmentTypeConfig(etc2.id)
+      .disassociate();
+  });
+});
+
+async function _waitForEnvironmentToReachState(
+  session: ClientSession,
+  projectId: string,
+  envId: string,
+  transitionState: string,
+  desiredState: string,
+  timeout: number
+): Promise<void> {
+  await poll(
+    async () => session.resources.projects.project(projectId).environments().environment(envId).get(),
+    (env) => env?.data?.status !== transitionState,
+    timeout
+  );
+  const { data: env } = await session.resources.projects
+    .project(projectId)
+    .environments()
+    .environment(envId)
+    .get();
+  expect(env).toMatchObject({
+    id: expect.stringMatching(envUuidRegExp),
+    status: desiredState,
+    ETC: expect.anything(), //ETC should be defined
+    PROJ: expect.anything() // PROJ should be defined
+  });
+  console.log(`Environment ${envId} reached state ${env.status}.`);
+}

--- a/solutions/swb-reference/src/dynamicRouteConfig.ts
+++ b/solutions/swb-reference/src/dynamicRouteConfig.ts
@@ -107,6 +107,17 @@ export const dynamicRoutesMap: DynamicRoutesMap = {
       }
     ]
   },
+  '/datasets/:datasetId': {
+    GET: [
+      {
+        action: 'READ',
+        subject: {
+          subjectType: SwbAuthZSubject.SWB_DATASET,
+          subjectId: '${datasetId}'
+        }
+      }
+    ]
+  },
   '/projects/:projectId/datasets': {
     GET: [
       {
@@ -177,14 +188,12 @@ export const dynamicRoutesMap: DynamicRoutesMap = {
         action: 'READ',
         subject: {
           subjectType: SwbAuthZSubject.SWB_DATASET,
-          subjectId: '${datasetId}',
-          projectId: '${projectId}'
+          subjectId: '${datasetId}'
         }
       }
     ]
   },
   '/projects/:projectId/datasets/import': {
-    // May need to add datasetId into this for authz
     POST: [
       {
         action: 'CREATE',
@@ -197,7 +206,6 @@ export const dynamicRoutesMap: DynamicRoutesMap = {
     ]
   },
   '/projects/:projectId/datasets/share': {
-    // May need to add datasetId into this for authz
     POST: [
       {
         action: 'CREATE',

--- a/solutions/swb-reference/src/postDeployment/authorizationSetup.ts
+++ b/solutions/swb-reference/src/postDeployment/authorizationSetup.ts
@@ -45,11 +45,7 @@ export default class AuthorizationSetup {
     ]);
     const environmentTypePermissions = this._mapActions(itAdmin, SwbAuthZSubject.SWB_ENVIRONMENT_TYPE);
     const environmentTypeConfigPermissions = this._mapActions(itAdmin, SwbAuthZSubject.SWB_ETC);
-    const datasetPermissions = this._mapActions(itAdmin, SwbAuthZSubject.SWB_DATASET, [
-      'READ',
-      'UPDATE',
-      'DELETE'
-    ]);
+    const datasetPermissions = this._mapActions(itAdmin, SwbAuthZSubject.SWB_DATASET, ['READ']);
     const awsAccountTemplateUrlsPermissions = this._mapActions(
       itAdmin,
       SwbAuthZSubject.SWB_AWS_ACCOUNT_TEMPLATE_URL,

--- a/solutions/swb-reference/src/services/swbProjectService.ts
+++ b/solutions/swb-reference/src/services/swbProjectService.ts
@@ -175,9 +175,6 @@ export class SWBProjectService implements ProjectPlugin {
     return this._projectService.updateProject(request);
   }
 
-  /**
-   *
-   */
   private _generatePAIdentityPermissions(projectId: string, paRole: string): IdentityPermission[] {
     return [
       ...this._generateIdentityPermissions('*', SwbAuthZSubject.SWB_DATASET, ['CREATE', 'READ'], paRole, {
@@ -219,9 +216,6 @@ export class SWBProjectService implements ProjectPlugin {
     ];
   }
 
-  /**
-   *
-   */
   private _generateResearcherIdentityPermissions(
     projectId: string,
     researcherRole: string


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Add happy path integ test for project as a boundary
* Add GetDataset route for ITAdmin only to be used for integ tests
* Update ITAdmin Dataset permissions so that they can only GetDataset

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.