### PR TITLE
fix: revert change to CreateDataSet schema object

### DIFF
--- a/common/changes/@aws/workbench-core-datasets/fix-revert-create-dataset-schema-change_2023-02-27-18-32.json
+++ b/common/changes/@aws/workbench-core-datasets/fix-revert-create-dataset-schema-change_2023-02-27-18-32.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-datasets",
+      "comment": "Reverted accidental change to CreateDataSet schema object.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-datasets"
+}

--- a/workbench-core/datasets/src/schemas/createDataSet.ts
+++ b/workbench-core/datasets/src/schemas/createDataSet.ts
@@ -15,6 +15,8 @@ const CreateDataSetSchema: Schema = {
     path: { type: 'string' },
     awsAccountId: { type: 'string' },
     region: { type: 'string' },
+    owner: { type: 'string' },
+    ownerType: { type: 'string' },
     permissions: {
       type: 'array',
       items: {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- reverted accidental change to `CreateDataSet` schema object

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.