### PR TITLE
fix: update Setup to not be a singleton in order to avoid expired cre…

### DIFF
--- a/solutions/swb-reference/integration-tests/support/setup.ts
+++ b/solutions/swb-reference/integration-tests/support/setup.ts
@@ -33,7 +33,7 @@ export default class Setup {
   }
 
   public static getSetup(): Setup {
-    return this._setup;
+    return new Setup();
   }
 
   public async createAnonymousSession(): Promise<ClientSession> {


### PR DESCRIPTION
…dentials

Description of changes:
* Integration tests take longer than an hour, causing sdk credentials to expire. Updating Setup to not be a singleton so that the credentials get refreshed for every test.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.