### PR TITLE
chore: cost center test fix

### DIFF
--- a/solutions/swb-reference/integration-tests/tests/isolated/costCenter/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/costCenter/create.test.ts
@@ -41,7 +41,7 @@ describe('Cost Center negative tests', () => {
             e,
             new HttpError(400, {
               error: 'Bad Request',
-              message: "requires property 'name'"
+              message: 'name: Required'
             })
           );
         }
@@ -60,7 +60,7 @@ describe('Cost Center negative tests', () => {
             e,
             new HttpError(400, {
               error: 'Bad Request',
-              message: "requires property 'description'"
+              message: 'description: Required'
             })
           );
         }
@@ -79,7 +79,7 @@ describe('Cost Center negative tests', () => {
             e,
             new HttpError(400, {
               error: 'Bad Request',
-              message: "requires property 'accountId'"
+              message: 'accountId: Required'
             })
           );
         }


### PR DESCRIPTION
Description of changes:
Tests check the message that gets returned instead of having a set of data that lets the user know what went wrong. I forgot to update that.
