### PR TITLE
feat: increase github workflow assume role for swb-reference to 2 hours

### DIFF
--- a/.github/workflows/deploy-integration-swb-reference-byon.yml
+++ b/.github/workflows/deploy-integration-swb-reference-byon.yml
@@ -61,6 +61,7 @@ jobs:
           aws-region: ${{ secrets.aws-dev-region }}
           role-to-assume: ${{ secrets.role-to-assume }}
           role-session-name: OIDCSessionName
+          role-duration-seconds: 7200
 
       - name: Enter config settings from GH secrets
         shell: bash

--- a/.github/workflows/deploy-integration-swb-reference.yml
+++ b/.github/workflows/deploy-integration-swb-reference.yml
@@ -45,6 +45,7 @@ jobs:
           aws-region: ${{ secrets.aws-dev-region }}
           role-to-assume: ${{ secrets.role-to-assume }}
           role-session-name: OIDCSessionName
+          role-duration-seconds: 7200
 
       - name: Enter config settings from GH secrets
         shell: bash


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* swb-reference and swb-reference-byon github workflow assume roles increased to 2 hours to avoid timeout

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.