### PR TITLE
topic: user pool advanced security mode

### DIFF
--- a/common/changes/@aws/workbench-core-infrastructure/topic-userPoolAdvancedSecurityMode_2023-03-06-22-26.json
+++ b/common/changes/@aws/workbench-core-infrastructure/topic-userPoolAdvancedSecurityMode_2023-03-06-22-26.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-infrastructure",
+      "comment": "Adding support for user pool advanced security mode",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@aws/workbench-core-infrastructure"
+}

--- a/workbench-core/infrastructure/src/workbenchCognito.test.ts
+++ b/workbench-core/infrastructure/src/workbenchCognito.test.ts
@@ -5,7 +5,7 @@
 
 import { Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { Mfa, ProviderAttribute } from 'aws-cdk-lib/aws-cognito';
+import { AdvancedSecurityMode, Mfa, ProviderAttribute } from 'aws-cdk-lib/aws-cognito';
 import {
   WorkbenchCognito,
   WorkbenchCognitoProps,
@@ -58,6 +58,9 @@ describe('WorkbenchCognito tests', () => {
       UsernameAttributes: ['email'],
       UsernameConfiguration: {
         CaseSensitive: false
+      },
+      UserPoolAddOns: {
+        AdvancedSecurityMode: 'ENFORCED'
       }
     });
 
@@ -106,7 +109,8 @@ describe('WorkbenchCognito tests', () => {
       idTokenValidity: Duration.hours(1),
       refreshTokenValidity: Duration.hours(24),
       mfa: Mfa.REQUIRED,
-      removalPolicy: RemovalPolicy.DESTROY
+      removalPolicy: RemovalPolicy.DESTROY,
+      advancedSecurityMode: AdvancedSecurityMode.AUDIT
     };
     const stack = new Stack();
     new WorkbenchCognito(stack, 'TestWorkbenchCognito', workbenchCognitoProps);
@@ -149,7 +153,10 @@ describe('WorkbenchCognito tests', () => {
       UsernameConfiguration: {
         CaseSensitive: false
       },
-      UserPoolName: workbenchCognitoProps.userPoolName
+      UserPoolName: workbenchCognitoProps.userPoolName,
+      UserPoolAddOns: {
+        AdvancedSecurityMode: 'AUDIT'
+      }
     });
 
     // test removal policy

--- a/workbench-core/infrastructure/src/workbenchCognito.ts
+++ b/workbench-core/infrastructure/src/workbenchCognito.ts
@@ -6,6 +6,7 @@
 import { Duration, RemovalPolicy, SecretValue, Stack } from 'aws-cdk-lib';
 import {
   AccountRecovery,
+  AdvancedSecurityMode,
   Mfa,
   OAuthScope,
   UserPool,
@@ -45,7 +46,8 @@ const userPoolDefaults: UserPoolProps = {
   mfaSecondFactor: {
     sms: false,
     otp: true
-  }
+  },
+  advancedSecurityMode: AdvancedSecurityMode.ENFORCED
 };
 
 const userPoolClientDefaults: UserPoolClientOptions = {
@@ -80,6 +82,7 @@ export interface WorkbenchCognitoProps {
   refreshTokenValidity?: Duration;
   mfa?: Mfa;
   removalPolicy?: RemovalPolicy;
+  advancedSecurityMode?: AdvancedSecurityMode;
 }
 
 export interface WorkbenchUserPoolOidcIdentityProvider
@@ -107,7 +110,8 @@ export class WorkbenchCognito extends Construct {
     const tempUserPoolProps: UserPoolProps = {
       mfa: props.mfa,
       userPoolName: props.userPoolName,
-      removalPolicy: props.removalPolicy
+      removalPolicy: props.removalPolicy,
+      advancedSecurityMode: props.advancedSecurityMode
     };
 
     const userPoolProps = merge(userPoolDefaults, tempUserPoolProps);


### PR DESCRIPTION
Issue #, if available: https://issues.amazon.com/issues/GALI-1689

Description of changes:

This PR adds support for new `workbenchCognito` parameter `advancedSecurityMode` defining UserPool's [AdvancedSecurityPropert](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-userpooladdons.html) and sets it by default to `ENFORCED`.

Checklist:

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.