### PR TITLE
test(sshkeys): fix create test and delete

### DIFF
--- a/solutions/swb-reference/integration-tests/support/resources/sshKeys/sshKey.ts
+++ b/solutions/swb-reference/integration-tests/support/resources/sshKeys/sshKey.ts
@@ -13,7 +13,7 @@ export default class SshKey extends Resource {
   protected async cleanup(): Promise<void> {
     try {
       console.log(`Attempting to delete SSH Key ${this._id}.`);
-      await this.delete();
+      await this.purge();
     } catch (e) {
       console.warn(
         `Could not delete SSH Key ${this._id}". 

--- a/solutions/swb-reference/integration-tests/tests/isolated/sshKeys/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/sshKeys/create.test.ts
@@ -29,8 +29,6 @@ describe('cannot create SSH key', () => {
   });
 
   describe('when the user already has a key for that project', () => {
-    let existingSshKeyId: string;
-
     const testBundle = [
       {
         username: 'projectAdmin1',
@@ -52,11 +50,7 @@ describe('cannot create SSH key', () => {
       beforeEach(async () => {
         session = sessionFunc();
         project1Id = projectIdFunc();
-        const { data: existingSshKey } = await session.resources.projects
-          .project(project1Id)
-          .sshKeys()
-          .create();
-        existingSshKeyId = existingSshKey.id;
+        await session.resources.projects.project(project1Id).sshKeys().create();
       });
 
       test(`it throws 400 error as ${username}`, async () => {
@@ -67,7 +61,7 @@ describe('cannot create SSH key', () => {
             e,
             new HttpError(400, {
               error: 'Bad Request',
-              message: `The keypair '${existingSshKeyId}' already exists.`
+              message: `The keypair already exists`
             })
           );
         }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fix cleanup for ssh key to use purge, not delete, since the delete is a hard delete and we added a purge route
Fix message of an error in the test to match actually thrown error

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.