### PR TITLE
chore: adding sonarqube coverage paths

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -37,8 +37,23 @@ sonar.coverage.exclusions=\
 # so we have to provide an explicit list of reportPaths
 #
 # Example: Uncomment next section for javascript/typescript code
-#sonar.javascript.lcov.reportPaths= \
-#    source/test/coverage-reports/jest/example-function-js/lcov.info
+sonar.javascript.lcov.reportPaths= \
+    ./solutions/swb-reference/temp/coverage/lcov.info,\
+    ./workbench-core/datasets-ui/temp/coverage/lcov.info,\
+    ./workbench-core/datasets-ui/coverage/lcov.info,\
+    ./workbench-core/datasets/temp/coverage/lcov.info,\
+    ./workbench-core/accounts-ui/temp/coverage/lcov.info,\
+    ./workbench-core/audit/temp/coverage/lcov.info,\
+    ./workbench-core/accounts/temp/coverage/lcov.info,\
+    ./workbench-core/swb-common-ui/temp/coverage/lcov.info,\
+    ./workbench-core/swb-common-ui/coverage/lcov.info,\
+    ./workbench-core/user-management/temp/coverage/lcov.info,\
+    ./workbench-core/infrastructure/temp/coverage/lcov.info,\
+    ./workbench-core/authorization/temp/coverage/lcov.info,\
+    ./workbench-core/authentication/temp/coverage/lcov.info,\
+    ./workbench-core/logging/temp/coverage/lcov.info,\
+    ./workbench-core/environments-ui/temp/coverage/lcov.info,\
+    ./workbench-core/environments-ui/coverage/lcov.info
 
 # Encoding of the source files
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Issue #, if available:
GALI-2027

Description of changes:
Adding lcov paths for NightsWatch Sonar Qube coverage report.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.