### PR TITLE
fix(appsec): update listener SSL policy

### DIFF
--- a/solutions/swb-reference/src/SWBStack.ts
+++ b/solutions/swb-reference/src/SWBStack.ts
@@ -26,6 +26,7 @@ import { AttributeType, BillingMode, Table, TableEncryption } from 'aws-cdk-lib/
 import {
   ApplicationTargetGroup,
   ListenerCondition,
+  SslPolicy,
   TargetType
 } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { LambdaTarget } from 'aws-cdk-lib/aws-elasticloadbalancingv2-targets';
@@ -472,18 +473,8 @@ export class SWBStack extends Stack {
     });
     const httpsListener = alb.applicationLoadBalancer.addListener('HTTPSListener', {
       port: 443,
-      certificates: [certificate]
-    });
-
-    const listenerMetadataNode = httpsListener.node.defaultChild as CfnResource;
-    listenerMetadataNode.addMetadata('cfn_nag', {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      rules_to_suppress: [
-        {
-          id: 'W55',
-          reason: 'TODO: Elastic Load Balancer V2 Listener SslPolicy should use TLS 1.2'
-        }
-      ]
+      certificates: [certificate],
+      sslPolicy: SslPolicy.RECOMMENDED_TLS
     });
 
     const targetGroup = new ApplicationTargetGroup(this, 'proxyLambdaTargetGroup', {


### PR DESCRIPTION
Issue #, if available: GALI-2397

Description of changes:

set ELB V2 Listener to use ELBSecurityPolicy-TLS13-1-2-2021-06 security policy in place of ELBSecurityPolicy-2016-08

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.