### PR TITLE
test: replacing toMatchObject with toStrictEqual

### DIFF
--- a/.viperlightignore
+++ b/.viperlightignore
@@ -28,7 +28,7 @@ solutions/example-ui-app/src/models/User.ts:19
 # "email": "hello@cypress.io" is not real email
 solutions/swb-ui/ui/end-to-end-tests/cypress/fixtures/example.json:3
 # Fake emails for UserManagementService integ tests
-workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts:28
+workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts:22
 workbench-core/example/infrastructure/integration-tests/tests/users/createUser.test.ts:23
 workbench-core/example/infrastructure/integration-tests/tests/users/listUsers.test.ts:31
 workbench-core/example/infrastructure/integration-tests/tests/users/listUsers.test.ts:37

--- a/.viperlightignore
+++ b/.viperlightignore
@@ -28,7 +28,7 @@ solutions/example-ui-app/src/models/User.ts:19
 # "email": "hello@cypress.io" is not real email
 solutions/swb-ui/ui/end-to-end-tests/cypress/fixtures/example.json:3
 # Fake emails for UserManagementService integ tests
-workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts:30
+workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts:28
 workbench-core/example/infrastructure/integration-tests/tests/users/createUser.test.ts:23
 workbench-core/example/infrastructure/integration-tests/tests/users/listUsers.test.ts:31
 workbench-core/example/infrastructure/integration-tests/tests/users/listUsers.test.ts:37
@@ -43,7 +43,7 @@ workbench-core/example/infrastructure/integration-tests/tests/dynamicAuthorizati
 # Fake email for DataSetsService integration tests
 workbench-core/example/infrastructure/integration-tests/tests/datasets/accessPermissions.test.ts:31
 workbench-core/example/infrastructure/integration-tests/tests/datasets/delete.test.ts:30
-workbench-core/example/infrastructure/integration-tests/tests/datasets/byob.test.ts:61
+workbench-core/example/infrastructure/integration-tests/tests/datasets/byob.test.ts:68
 workbench-core/example/infrastructure/integration-tests/tests/datasets/create.test.ts:106
 #Fake email used
 workbench-core/example/infrastructure/scripts/setupCognito.sh:43

--- a/common/changes/@aws/workbench-core-audit/topic-expectToStrictEqual_2023-04-04-14-47.json
+++ b/common/changes/@aws/workbench-core-audit/topic-expectToStrictEqual_2023-04-04-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-audit",
+      "comment": "Replacing toMatchObject with toStrictEqual",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-audit"
+}

--- a/common/changes/@aws/workbench-core-authentication/topic-expectToStrictEqual_2023-04-04-14-47.json
+++ b/common/changes/@aws/workbench-core-authentication/topic-expectToStrictEqual_2023-04-04-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-authentication",
+      "comment": "Replacing toMatchObject with toStrictEqual",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-authentication"
+}

--- a/common/changes/@aws/workbench-core-authorization/topic-expectToStrictEqual_2023-04-04-14-47.json
+++ b/common/changes/@aws/workbench-core-authorization/topic-expectToStrictEqual_2023-04-04-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-authorization",
+      "comment": "Replacing toMatchObject with toStrictEqual",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-authorization"
+}

--- a/common/changes/@aws/workbench-core-base/topic-expectToStrictEqual_2023-04-04-14-47.json
+++ b/common/changes/@aws/workbench-core-base/topic-expectToStrictEqual_2023-04-04-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "Replacing toMatchObject with toStrictEqual",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/common/changes/@aws/workbench-core-datasets/topic-expectToStrictEqual_2023-04-04-14-47.json
+++ b/common/changes/@aws/workbench-core-datasets/topic-expectToStrictEqual_2023-04-04-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-datasets",
+      "comment": "Replacing toMatchObject with toStrictEqual",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-datasets"
+}

--- a/common/changes/@aws/workbench-core-environments/topic-expectToStrictEqual_2023-04-04-14-47.json
+++ b/common/changes/@aws/workbench-core-environments/topic-expectToStrictEqual_2023-04-04-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-environments",
+      "comment": "Replacing toMatchObject with toStrictEqual",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-environments"
+}

--- a/common/changes/@aws/workbench-core-logging/topic-expectToStrictEqual_2023-04-04-14-47.json
+++ b/common/changes/@aws/workbench-core-logging/topic-expectToStrictEqual_2023-04-04-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-logging",
+      "comment": "Replacing toMatchObject with toStrictEqual",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-logging"
+}

--- a/common/changes/@aws/workbench-core-user-management/topic-expectToStrictEqual_2023-04-04-14-47.json
+++ b/common/changes/@aws/workbench-core-user-management/topic-expectToStrictEqual_2023-04-04-14-47.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-user-management",
+      "comment": "Replacing toMatchObject with toStrictEqual",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-user-management"
+}

--- a/workbench-core/audit/src/plugins/baseAuditPlugin.test.ts
+++ b/workbench-core/audit/src/plugins/baseAuditPlugin.test.ts
@@ -31,7 +31,7 @@ describe('BaseAuditPlugin', () => {
     test('Prepare audit entry', async () => {
       await baseAuditPlugin.prepare(metadata, auditEntry);
 
-      expect(auditEntry).toMatchObject({
+      expect(auditEntry).toStrictEqual({
         statusCode: 200,
         action: 'GET /user',
         source: { ip: 'sampleIP' },
@@ -46,7 +46,7 @@ describe('BaseAuditPlugin', () => {
       metadata.moreInfo = moreInfo;
       await baseAuditPlugin.prepare(metadata, auditEntry);
 
-      expect(auditEntry).toMatchObject({
+      expect(auditEntry).toStrictEqual({
         statusCode: 200,
         action: 'GET /user',
         source: { ip: 'sampleIP' },

--- a/workbench-core/authentication/src/authenticationMiddleware.test.ts
+++ b/workbench-core/authentication/src/authenticationMiddleware.test.ts
@@ -517,7 +517,7 @@ describe('authenticationMiddleware tests', () => {
 
       await verifyTokenMiddleware(req, res, next);
 
-      expect(res.locals.user).toMatchObject({ id: 'id', roles: ['role'] });
+      expect(res.locals.user).toStrictEqual({ id: 'id', roles: ['role'] });
       expect(next).toHaveBeenCalledTimes(1);
     });
 
@@ -566,7 +566,7 @@ describe('authenticationMiddleware tests', () => {
 
       await verifyTokenMiddleware(req, res, next);
 
-      expect(res.locals.user).toMatchObject({ id: 'id', roles: ['role'] });
+      expect(res.locals.user).toStrictEqual({ id: 'id', roles: ['role'] });
       expect(next).toHaveBeenCalledTimes(1);
     });
 

--- a/workbench-core/authentication/src/authenticationService.test.ts
+++ b/workbench-core/authentication/src/authenticationService.test.ts
@@ -39,7 +39,7 @@ describe('AuthenticationService tests', () => {
   it('validateToken should return the decoded passed in token', async () => {
     const result = await service.validateToken('valid token');
 
-    expect(result).toMatchObject({
+    expect(result).toStrictEqual({
       token_use: 'access',
       sub: 'sub',
       iss: 'iss',
@@ -67,7 +67,7 @@ describe('AuthenticationService tests', () => {
   it('getUserRolesFromToken should return the tokens roles', () => {
     const result = service.getUserRolesFromToken({});
 
-    expect(result).toMatchObject(['role']);
+    expect(result).toStrictEqual(['role']);
   });
 
   it('handleAuthorizationCode should return a Promise that contains the id, access, and refresh tokens and their expiration (in seconds)', async () => {
@@ -77,7 +77,7 @@ describe('AuthenticationService tests', () => {
       'https://www.fakewebsite.com'
     );
 
-    expect(result).toMatchObject({
+    expect(result).toStrictEqual({
       idToken: {
         token: 'id token',
         expiresIn: 1234
@@ -107,7 +107,7 @@ describe('AuthenticationService tests', () => {
   it('refreshAccessToken should return a Promise that contains the id and access tokens and their expiration (in seconds)', async () => {
     const result = await service.refreshAccessToken('refresh token');
 
-    expect(result).toMatchObject({
+    expect(result).toStrictEqual({
       idToken: {
         token: 'id token',
         expiresIn: 1234

--- a/workbench-core/authentication/src/plugins/cognitoAuthenticationPlugin.test.ts
+++ b/workbench-core/authentication/src/plugins/cognitoAuthenticationPlugin.test.ts
@@ -147,7 +147,7 @@ describe('CognitoAuthenticationPlugin tests', () => {
 
       const decoded = await plugin.validateToken('validToken');
 
-      expect(decoded).toMatchObject(baseDecodedAccessToken);
+      expect(decoded).toStrictEqual(baseDecodedAccessToken);
     });
 
     it('should throw InvalidJWTError when an invalid token is passed in', async () => {
@@ -292,13 +292,13 @@ describe('CognitoAuthenticationPlugin tests', () => {
         'cognito:groups': ['Admin']
       });
 
-      expect(roles).toMatchObject(['Admin']);
+      expect(roles).toStrictEqual(['Admin']);
     });
 
     it('should return an empty array when the decoded token doesnt have the cognito:groups claim', () => {
       const roles = plugin.getUserRolesFromToken(baseDecodedAccessToken);
 
-      expect(roles).toMatchObject([]);
+      expect(roles).toStrictEqual([]);
     });
   });
 
@@ -336,7 +336,7 @@ describe('CognitoAuthenticationPlugin tests', () => {
           }
         }
       );
-      expect(tokens).toMatchObject({
+      expect(tokens).toStrictEqual({
         idToken: {
           token: 'id token',
           expiresIn: 1
@@ -554,7 +554,7 @@ describe('CognitoAuthenticationPlugin tests', () => {
           }
         }
       );
-      expect(tokens).toMatchObject({
+      expect(tokens).toStrictEqual({
         idToken: {
           token: 'id token',
           expiresIn: 1
@@ -692,7 +692,7 @@ describe('CognitoAuthenticationPlugin tests', () => {
 
       const tokens = await plugin['_getTokensExpirationinMS']();
 
-      expect(tokens).toMatchObject({ idToken: 1, accessToken: 1, refreshToken: 1 });
+      expect(tokens).toStrictEqual({ idToken: 1, accessToken: 1, refreshToken: 1 });
     });
 
     it('should return a TokensExpiration object when user pool token expiration is undefined', async () => {
@@ -704,7 +704,7 @@ describe('CognitoAuthenticationPlugin tests', () => {
 
       const tokens = await plugin['_getTokensExpirationinMS']();
 
-      expect(tokens).toMatchObject({ idToken: 1, accessToken: 1, refreshToken: 1 });
+      expect(tokens).toStrictEqual({ idToken: 1, accessToken: 1, refreshToken: 1 });
     });
 
     it('should throw PluginConfigurationError when the service doesnt have correct permissions', async () => {

--- a/workbench-core/authorization/src/dynamicAuthorization/dynamicAuthorizationService.test.ts
+++ b/workbench-core/authorization/src/dynamicAuthorization/dynamicAuthorizationService.test.ts
@@ -719,7 +719,7 @@ describe('DynamicAuthorizationService', () => {
 
       const response = await dynamicAuthzService.createGroup(params);
 
-      expect(response).toMatchObject<CreateGroupResponse>(mockReturnValue);
+      expect(response).toStrictEqual<CreateGroupResponse>(mockReturnValue);
       expect(auditServiceWriteSpy).toHaveBeenCalledWith(
         {
           actor: mockUser,
@@ -782,7 +782,7 @@ describe('DynamicAuthorizationService', () => {
 
       const response = await dynamicAuthzService.deleteGroup(params);
 
-      expect(response).toMatchObject<DeleteGroupResponse>(mockReturnValue);
+      expect(response).toStrictEqual<DeleteGroupResponse>(mockReturnValue);
       expect(auditServiceWriteSpy).toHaveBeenCalledWith(
         {
           actor: mockUser,
@@ -832,7 +832,7 @@ describe('DynamicAuthorizationService', () => {
       const deleteIdentityPermissionsSpy = jest.spyOn(dynamicAuthzService, 'deleteIdentityPermissions');
 
       const response = await dynamicAuthzService.deleteGroup(params);
-      expect(response).toMatchObject<DeleteGroupResponse>(mockReturnValue);
+      expect(response).toStrictEqual<DeleteGroupResponse>(mockReturnValue);
       expect(auditServiceWriteSpy).toHaveBeenCalledWith(
         {
           actor: mockUser,
@@ -1213,7 +1213,7 @@ describe('DynamicAuthorizationService', () => {
 
       const response = await dynamicAuthzService.removeUserFromGroup(params);
 
-      expect(response).toMatchObject<RemoveUserFromGroupResponse>(mockReturnValue);
+      expect(response).toStrictEqual<RemoveUserFromGroupResponse>(mockReturnValue);
       expect(auditServiceWriteSpy).toHaveBeenCalledWith(
         {
           actor: mockUser,
@@ -1252,7 +1252,7 @@ describe('DynamicAuthorizationService', () => {
 
       const response = await dynamicAuthzService.getGroupUsers({ groupId, authenticatedUser: mockUser });
 
-      expect(response).toMatchObject<GetGroupUsersResponse>({ data: { userIds: [userId] } });
+      expect(response).toStrictEqual<GetGroupUsersResponse>({ data: { userIds: [userId] } });
     });
 
     it('throws when the group cannot be found', async () => {
@@ -1272,7 +1272,7 @@ describe('DynamicAuthorizationService', () => {
 
       const response = await dynamicAuthzService.getUserGroups({ userId, authenticatedUser: mockUser });
 
-      expect(response).toMatchObject<GetUserGroupsResponse>({ data: { groupIds: [groupId] } });
+      expect(response).toStrictEqual<GetUserGroupsResponse>({ data: { groupIds: [groupId] } });
     });
 
     it('throws when the user cannot be found', async () => {
@@ -1296,7 +1296,7 @@ describe('DynamicAuthorizationService', () => {
         authenticatedUser: mockUser
       });
 
-      expect(response).toMatchObject<IsUserAssignedToGroupResponse>({ data: { isAssigned: true } });
+      expect(response).toStrictEqual<IsUserAssignedToGroupResponse>({ data: { isAssigned: true } });
     });
 
     it('throws when the user cannot be found', async () => {
@@ -1318,7 +1318,7 @@ describe('DynamicAuthorizationService', () => {
       const response = await dynamicAuthzService.doesGroupExist({
         groupId
       });
-      expect(response).toMatchObject<DoesGroupExistResponse>({ data: { exist: true } });
+      expect(response).toStrictEqual<DoesGroupExistResponse>({ data: { exist: true } });
     });
   });
 

--- a/workbench-core/authorization/src/dynamicAuthorization/wbcGroupManagementPlugin.test.ts
+++ b/workbench-core/authorization/src/dynamicAuthorization/wbcGroupManagementPlugin.test.ts
@@ -102,7 +102,7 @@ describe('WBCGroupManagemntPlugin', () => {
 
       const response = await wbcGroupManagementPlugin.createGroup({ groupId, authenticatedUser: mockUser });
 
-      expect(response).toMatchObject<CreateGroupResponse>({ data: { groupId } });
+      expect(response).toStrictEqual<CreateGroupResponse>({ data: { groupId } });
     });
 
     it('throws GroupAlreadyExistsError when the group is pending delete', async () => {
@@ -173,7 +173,7 @@ describe('WBCGroupManagemntPlugin', () => {
     it('returns the groupID in the data object when the group was successfully deleted', async () => {
       const response = await wbcGroupManagementPlugin.deleteGroup({ groupId, authenticatedUser: mockUser });
 
-      expect(response).toMatchObject<DeleteGroupResponse>({ data: { groupId } });
+      expect(response).toStrictEqual<DeleteGroupResponse>({ data: { groupId } });
     });
 
     test.each([
@@ -196,7 +196,7 @@ describe('WBCGroupManagemntPlugin', () => {
       mockUserManagementPlugin.getUserRoles = jest.fn().mockResolvedValue([groupId]);
       const response = await wbcGroupManagementPlugin.getUserGroups({ userId, authenticatedUser: mockUser });
 
-      expect(response).toMatchObject<GetUserGroupsResponse>({ data: { groupIds: [groupId] } });
+      expect(response).toStrictEqual<GetUserGroupsResponse>({ data: { groupIds: [groupId] } });
     });
 
     it('throws IdpUnavailableError when the IdP encounters an error', async () => {
@@ -245,7 +245,7 @@ describe('WBCGroupManagemntPlugin', () => {
       mockUserManagementPlugin.listUsersForRole = jest.fn().mockResolvedValue([userId]);
       const response = await wbcGroupManagementPlugin.getGroupUsers({ groupId, authenticatedUser: mockUser });
 
-      expect(response).toMatchObject<GetGroupUsersResponse>({ data: { userIds: [userId] } });
+      expect(response).toStrictEqual<GetGroupUsersResponse>({ data: { userIds: [userId] } });
     });
 
     it('throws IdpUnavailableError when the IdP encounters an error', async () => {
@@ -347,7 +347,7 @@ describe('WBCGroupManagemntPlugin', () => {
         authenticatedUser: mockUser
       });
 
-      expect(response).toMatchObject<IsUserAssignedToGroupResponse>({ data: { isAssigned: true } });
+      expect(response).toStrictEqual<IsUserAssignedToGroupResponse>({ data: { isAssigned: true } });
     });
 
     it('returns false in the data object when the user is not in the group', async () => {
@@ -358,7 +358,7 @@ describe('WBCGroupManagemntPlugin', () => {
         authenticatedUser: mockUser
       });
 
-      expect(response).toMatchObject<IsUserAssignedToGroupResponse>({ data: { isAssigned: false } });
+      expect(response).toStrictEqual<IsUserAssignedToGroupResponse>({ data: { isAssigned: false } });
     });
 
     it('throws IdpUnavailableError when the IdP encounters an error', async () => {
@@ -410,7 +410,7 @@ describe('WBCGroupManagemntPlugin', () => {
         authenticatedUser: mockUser
       });
 
-      expect(response).toMatchObject<RemoveUserFromGroupResponse>({ data: { groupId, userId } });
+      expect(response).toStrictEqual<RemoveUserFromGroupResponse>({ data: { groupId, userId } });
     });
 
     it('throws IdpUnavailableError when the IdP encounters an error', async () => {
@@ -479,7 +479,7 @@ describe('WBCGroupManagemntPlugin', () => {
 
       const response = await wbcGroupManagementPlugin.getGroupStatus({ groupId });
 
-      expect(response).toMatchObject<GetGroupStatusResponse>({ data: { status } });
+      expect(response).toStrictEqual<GetGroupStatusResponse>({ data: { status } });
     });
 
     it('throws GroupNotFoundError when the group doesnt exist', async () => {
@@ -525,19 +525,19 @@ describe('WBCGroupManagemntPlugin', () => {
     it('returns the status in the data object when the status was successfully set for active', async () => {
       ddbMock.on(UpdateItemCommand).resolves({});
       const response = await wbcGroupManagementPlugin.setGroupStatus({ groupId, status });
-      expect(response).toMatchObject<SetGroupStatusResponse>({ data: { status } });
+      expect(response).toStrictEqual<SetGroupStatusResponse>({ data: { status } });
     });
 
     it('returns the status in the data object when the status was successfully set for delete_pending', async () => {
       ddbMock.on(UpdateItemCommand).resolves({});
       const response = await wbcGroupManagementPlugin.setGroupStatus({ groupId, status: 'delete_pending' });
-      expect(response).toMatchObject<SetGroupStatusResponse>({ data: { status: 'delete_pending' } });
+      expect(response).toStrictEqual<SetGroupStatusResponse>({ data: { status: 'delete_pending' } });
     });
 
     it('returns the status in the data object when the status was successfully set for deleted', async () => {
       ddbMock.on(DeleteItemCommand).resolves({});
       const response = await wbcGroupManagementPlugin.setGroupStatus({ groupId, status: 'deleted' });
-      expect(response).toMatchObject<SetGroupStatusResponse>({ data: { status: 'deleted' } });
+      expect(response).toStrictEqual<SetGroupStatusResponse>({ data: { status: 'deleted' } });
     });
 
     it('throws ForbiddenError when status tried to go from delete_pending to active', async () => {
@@ -590,7 +590,7 @@ describe('WBCGroupManagemntPlugin', () => {
     it('group does exist when status is active', async () => {
       wbcGroupManagementPlugin.getGroupStatus = jest.fn().mockResolvedValue({ data: { status: 'active' } });
       const response = await wbcGroupManagementPlugin.doesGroupExist({ groupId });
-      expect(response).toMatchObject<DoesGroupExistResponse>({ data: { exist: true } });
+      expect(response).toStrictEqual<DoesGroupExistResponse>({ data: { exist: true } });
     });
 
     it('group does not exist when status is delete_pending', async () => {
@@ -598,13 +598,13 @@ describe('WBCGroupManagemntPlugin', () => {
         .fn()
         .mockResolvedValue({ data: { status: 'delete_pending' } });
       const response = await wbcGroupManagementPlugin.doesGroupExist({ groupId });
-      expect(response).toMatchObject<DoesGroupExistResponse>({ data: { exist: false } });
+      expect(response).toStrictEqual<DoesGroupExistResponse>({ data: { exist: false } });
     });
 
     it('group does not exist when status does not exist', async () => {
       wbcGroupManagementPlugin.getGroupStatus = jest.fn().mockRejectedValue(new GroupNotFoundError());
       const response = await wbcGroupManagementPlugin.doesGroupExist({ groupId });
-      expect(response).toMatchObject<DoesGroupExistResponse>({ data: { exist: false } });
+      expect(response).toStrictEqual<DoesGroupExistResponse>({ data: { exist: false } });
     });
 
     it('throw error if getGroupStatus encounters error', async () => {

--- a/workbench-core/base/src/aws/helpers/dynamoDB/dynamoDBService.test.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/dynamoDBService.test.ts
@@ -162,7 +162,7 @@ describe('DynamoDBService', () => {
       const generatedParams = dbService.batchEdit(developerParams).getParams();
 
       // CHECK
-      expect(generatedParams).toMatchObject(expectedParams);
+      expect(generatedParams).toStrictEqual(expectedParams);
     });
     test('should populate params with optional param: addDeleteRequests', async () => {
       // BUILD
@@ -240,7 +240,7 @@ describe('DynamoDBService', () => {
       const generatedParams = dbService.batchEdit(developerParams).getParams();
 
       // CHECK
-      expect(generatedParams).toMatchObject(expectedParams);
+      expect(generatedParams).toStrictEqual(expectedParams);
     });
   });
 

--- a/workbench-core/base/src/aws/helpers/dynamoDB/transactEdit.test.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/transactEdit.test.ts
@@ -80,7 +80,7 @@ describe('transactEdit', () => {
         }
       ]
     };
-    expect(response).toMatchObject(expectedResponse);
+    expect(response).toStrictEqual(expectedResponse);
   });
 
   test('addPutRequests', async () => {
@@ -166,7 +166,7 @@ describe('transactEdit', () => {
         }
       ]
     };
-    expect(response).toMatchObject(expectedResponse);
+    expect(response).toStrictEqual(expectedResponse);
   });
 
   test('addDeleteRequest', async () => {
@@ -215,6 +215,6 @@ describe('transactEdit', () => {
         }
       ]
     };
-    expect(response).toMatchObject(expectedResponse);
+    expect(response).toStrictEqual(expectedResponse);
   });
 });

--- a/workbench-core/base/src/services/metadataService.test.ts
+++ b/workbench-core/base/src/services/metadataService.test.ts
@@ -82,7 +82,7 @@ describe('metadata service', () => {
       ]
     };
 
-    expect(metadataService.getMetadataItems(entityA, [entityB], mapperA, mapperB)).toMatchObject(result);
+    expect(metadataService.getMetadataItems(entityA, [entityB], mapperA, mapperB)).toStrictEqual(result);
   });
 
   test('should list dependent entity metadata', async () => {

--- a/workbench-core/datasets/src/dataSetService.test.ts
+++ b/workbench-core/datasets/src/dataSetService.test.ts
@@ -410,7 +410,7 @@ describe('DataSetService', () => {
           storageProvider: s3Plugin,
           authenticatedUser: mockAuthenticatedUser
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         name: mockDataSetName,
         path: mockDataSetPath,
@@ -434,7 +434,7 @@ describe('DataSetService', () => {
           storageProvider: s3Plugin,
           authenticatedUser: mockAuthenticatedUser
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         createdAt: mockCreatedAt,
         name: mockDataSetName,
@@ -472,7 +472,7 @@ describe('DataSetService', () => {
           authenticatedUser: mockAuthenticatedUser,
           permissions: [mockReadWriteUserPermission]
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         createdAt: mockCreatedAt,
         name: mockDataSetName,
@@ -510,7 +510,7 @@ describe('DataSetService', () => {
           authenticatedUser: mockAuthenticatedUser,
           permissions: [mockReadWriteGroupPermission]
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         createdAt: mockCreatedAt,
         name: mockDataSetName,
@@ -549,7 +549,7 @@ describe('DataSetService', () => {
           owner: mockOwnerUserId,
           ownerType: 'USER'
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         createdAt: mockCreatedAt,
         name: mockDataSetName,
@@ -588,7 +588,7 @@ describe('DataSetService', () => {
           owner: mockGroupId,
           ownerType: 'GROUP'
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         createdAt: mockCreatedAt,
         name: mockDataSetName,
@@ -680,7 +680,7 @@ describe('DataSetService', () => {
           storageProvider: s3Plugin,
           authenticatedUser: mockAuthenticatedUser
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         name: mockDataSetName,
         path: mockDataSetPath,
@@ -733,7 +733,7 @@ describe('DataSetService', () => {
           authenticatedUser: mockAuthenticatedUser,
           permissions: [mockReadWriteUserPermission]
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         createdAt: mockCreatedAt,
         name: mockDataSetName,
@@ -771,7 +771,7 @@ describe('DataSetService', () => {
           authenticatedUser: mockAuthenticatedUser,
           permissions: [mockReadWriteGroupPermission]
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         createdAt: mockCreatedAt,
         name: mockDataSetName,
@@ -810,7 +810,7 @@ describe('DataSetService', () => {
           owner: mockOwnerUserId,
           ownerType: 'USER'
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         createdAt: mockCreatedAt,
         name: mockDataSetName,
@@ -849,7 +849,7 @@ describe('DataSetService', () => {
           owner: mockGroupId,
           ownerType: 'GROUP'
         })
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         createdAt: mockCreatedAt,
         name: mockDataSetName,
@@ -906,14 +906,15 @@ describe('DataSetService', () => {
         .mockImplementationOnce(async () => dataSetPermissionsResponse);
       await expect(
         dataSetService.removeDataSet(mockDataSetId, () => Promise.resolve(), mockAuthenticatedUser)
-      ).resolves.toMatchObject({
+      ).resolves.toStrictEqual({
         id: mockDataSetId,
         name: mockDataSetName,
         path: mockDataSetPath,
         awsAccountId: mockAwsAccountId,
         storageType: mockDataSetStorageType,
         storageName: mockDataSetStorageName,
-        permissions: dataSetPermissionsResponse.data.permissions
+        permissions: dataSetPermissionsResponse.data.permissions,
+        createdAt: mockCreatedAt
       });
     });
     it('throws when an external endpoint exists on the DataSet.', async () => {
@@ -966,7 +967,7 @@ describe('DataSetService', () => {
           endpointId: mockExistingEndpointId,
           authenticatedUser: mockAuthenticatedUser
         })
-      ).resolves.toMatchObject<GetDataSetMountPointResponse>({
+      ).resolves.toStrictEqual<GetDataSetMountPointResponse>({
         data: {
           mountObject: {
             name: mockDataSetName,
@@ -1009,7 +1010,7 @@ describe('DataSetService', () => {
           endpointId: mockExistingEndpointId,
           authenticatedUser: { id: mockUserId, roles: [mockGroupId] }
         })
-      ).resolves.toMatchObject<GetDataSetMountPointResponse>({
+      ).resolves.toStrictEqual<GetDataSetMountPointResponse>({
         data: {
           mountObject: {
             name: mockDataSetName,
@@ -1149,7 +1150,7 @@ describe('DataSetService', () => {
       });
       jest.spyOn(WbcDataSetsAuthorizationPlugin.prototype, 'isAuthorizedOnDataSet').mockResolvedValue();
 
-      await expect(dataSetService.listDataSets(mockAuthenticatedUser, 3, undefined)).resolves.toMatchObject<
+      await expect(dataSetService.listDataSets(mockAuthenticatedUser, 3, undefined)).resolves.toStrictEqual<
         PaginatedResponse<DataSet>
       >({
         data: [
@@ -1176,7 +1177,7 @@ describe('DataSetService', () => {
         .mockRejectedValueOnce(new ForbiddenError()) // no permissions on dataset 2
         .mockResolvedValueOnce();
 
-      await expect(dataSetService.listDataSets(mockAuthenticatedUser, 3, undefined)).resolves.toMatchObject<
+      await expect(dataSetService.listDataSets(mockAuthenticatedUser, 3, undefined)).resolves.toStrictEqual<
         PaginatedResponse<DataSet>
       >({
         data: [
@@ -1258,7 +1259,7 @@ describe('DataSetService', () => {
     it('returns a the details of a DataSet.', async () => {
       await expect(
         dataSetService.getDataSet(mockDataSetName, mockAuthenticatedUser)
-      ).resolves.toMatchObject<DataSet>({
+      ).resolves.toStrictEqual<DataSet>({
         id: mockDataSetId,
         name: mockDataSetName,
         path: mockDataSetPath,
@@ -1294,14 +1295,15 @@ describe('DataSetService', () => {
             permissions: [mockReadWriteGroupPermission]
           }
         });
-      await expect(dataSetService.getDataSet(mockDataSetName, mockAuthenticatedUser)).resolves.toMatchObject({
+      await expect(dataSetService.getDataSet(mockDataSetName, mockAuthenticatedUser)).resolves.toStrictEqual({
         id: mockDataSetId,
         name: mockDataSetName,
         path: mockDataSetPath,
         awsAccountId: mockAwsAccountId,
         storageType: mockDataSetStorageType,
         storageName: mockDataSetStorageName,
-        permissions: [mockReadOnlyUserPermission, mockReadWriteGroupPermission]
+        permissions: [mockReadOnlyUserPermission, mockReadWriteGroupPermission],
+        createdAt: mockCreatedAt
       });
       expect(authzPlugin.getAllDataSetAccessPermissions).toHaveBeenCalledTimes(2);
     });
@@ -1324,7 +1326,7 @@ describe('DataSetService', () => {
           authenticatedUser: mockAuthenticatedUser,
           externalRoleName: mockRoleArn
         })
-      ).resolves.toMatchObject<AddDataSetExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddDataSetExternalEndpointResponse>({
         data: {
           mountObject: {
             name: mockDataSetName,
@@ -1394,7 +1396,7 @@ describe('DataSetService', () => {
           authenticatedUser: mockAuthenticatedUser,
           externalRoleName: mockRoleArn
         })
-      ).resolves.toMatchObject<AddDataSetExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddDataSetExternalEndpointResponse>({
         data: {
           mountObject: {
             name: mockDataSetName,
@@ -1663,7 +1665,7 @@ describe('DataSetService', () => {
     it('returns an array of known StorageLocations.', async () => {
       await expect(
         dataSetService.listStorageLocations(mockAuthenticatedUser, 3, undefined)
-      ).resolves.toMatchObject<PaginatedResponse<StorageLocation>>({
+      ).resolves.toStrictEqual<PaginatedResponse<StorageLocation>>({
         data: [
           {
             name: mockDataSetStorageName,
@@ -1743,7 +1745,7 @@ describe('DataSetService', () => {
     it('returns permssions on a dataset.', async () => {
       await expect(
         dataSetService.getAllDataSetAccessPermissions(mockDataSetId, mockAuthenticatedUser)
-      ).resolves.toMatchObject(mockAddAccessResponse);
+      ).resolves.toStrictEqual(mockAddAccessResponse);
     });
 
     it('returns permssions on a dataset with pageToken.', async () => {
@@ -1761,7 +1763,7 @@ describe('DataSetService', () => {
         });
       await expect(
         dataSetService.getAllDataSetAccessPermissions(mockDataSetId, mockAuthenticatedUser, undefined, 1)
-      ).resolves.toMatchObject({
+      ).resolves.toStrictEqual({
         ...mockAddAccessResponse,
         pageToken
       });
@@ -1789,7 +1791,7 @@ describe('DataSetService', () => {
           },
           mockAuthenticatedUser
         )
-      ).resolves.toMatchObject(mockAddAccessResponse);
+      ).resolves.toStrictEqual(mockAddAccessResponse);
     });
     it('throws when an invalid dataset Id is given.', async () => {
       try {
@@ -1834,7 +1836,7 @@ describe('DataSetService', () => {
     it('gets the external endpoint', async () => {
       await expect(
         dataSetService.getExternalEndPoint(mockDataSetId, mockExistingEndpointId, mockAuthenticatedUser)
-      ).resolves.toMatchObject<ExternalEndpoint>({
+      ).resolves.toStrictEqual<ExternalEndpoint>({
         id: mockExistingEndpointId,
         name: mockExistingEndpointName,
         dataSetId: mockDataSetId,

--- a/workbench-core/datasets/src/ddbDataSetMetadataPlugin.test.ts
+++ b/workbench-core/datasets/src/ddbDataSetMetadataPlugin.test.ts
@@ -91,7 +91,7 @@ describe('DdbDataSetMetadataPlugin', () => {
       });
 
       const response = await plugin.listDataSets(1, undefined);
-      expect(response).toMatchObject<PaginatedResponse<DataSet>>({
+      expect(response).toStrictEqual<PaginatedResponse<DataSet>>({
         data: [
           {
             id: mockDataSetId,
@@ -132,7 +132,7 @@ describe('DdbDataSetMetadataPlugin', () => {
       });
       const response = await plugin.getDataSetMetadata(mockDataSetId);
 
-      expect(response).toMatchObject<DataSet>({
+      expect(response).toStrictEqual<DataSet>({
         id: mockDataSetId,
         name: mockDataSetName,
         path: mockDataSetPath,
@@ -196,7 +196,7 @@ describe('DdbDataSetMetadataPlugin', () => {
       mockDdb.on(QueryCommand).resolves({});
 
       const newDataSet = await plugin.addDataSet(exampleDS);
-      expect(newDataSet).toMatchObject<DataSet>({
+      expect(newDataSet).toStrictEqual<DataSet>({
         ...exampleDS,
         id: mockDataSetId,
         createdAt: mockCreatedAt
@@ -296,7 +296,7 @@ describe('DdbDataSetMetadataPlugin', () => {
         accessLevel: mockAccessLevel
       };
 
-      await expect(plugin.addExternalEndpoint(exampleEndpoint)).resolves.toMatchObject<ExternalEndpoint>({
+      await expect(plugin.addExternalEndpoint(exampleEndpoint)).resolves.toStrictEqual<ExternalEndpoint>({
         id: mockEndpointId,
         dataSetId: mockDataSetId,
         dataSetName: mockDataSetName,
@@ -390,7 +390,7 @@ describe('DdbDataSetMetadataPlugin', () => {
       });
       await expect(
         plugin.getDataSetEndPointDetails(mockDataSetId, mockEndpointName)
-      ).resolves.toMatchObject<ExternalEndpoint>({
+      ).resolves.toStrictEqual<ExternalEndpoint>({
         id: mockEndpointId,
         name: mockEndpointName,
         dataSetId: mockDataSetId,
@@ -425,7 +425,7 @@ describe('DdbDataSetMetadataPlugin', () => {
       const response = await plugin.listStorageLocations(1, undefined);
       expect(response.data).toBeDefined();
       expect(response.data).toHaveLength(1);
-      expect(response.data).toMatchObject<StorageLocation[]>([
+      expect(response.data).toStrictEqual<StorageLocation[]>([
         {
           name: mockDataSetStorageName,
           awsAccountId: mockAwsAccountId,

--- a/workbench-core/datasets/src/s3DataSetStoragePlugin.test.ts
+++ b/workbench-core/datasets/src/s3DataSetStoragePlugin.test.ts
@@ -184,7 +184,7 @@ describe('S3DataSetStoragePlugin', () => {
           accessLevel: 'read-only',
           externalRoleName
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -249,7 +249,7 @@ describe('S3DataSetStoragePlugin', () => {
           accessLevel: 'read-only',
           externalRoleName
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -352,7 +352,7 @@ describe('S3DataSetStoragePlugin', () => {
           accessLevel: 'read-only',
           externalRoleName
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -422,7 +422,7 @@ describe('S3DataSetStoragePlugin', () => {
           accessLevel: 'read-only',
           externalRoleName: externalRoleArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -487,7 +487,7 @@ describe('S3DataSetStoragePlugin', () => {
           accessLevel: 'read-only',
           externalRoleName: externalRoleArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -562,7 +562,7 @@ describe('S3DataSetStoragePlugin', () => {
           accessLevel: 'read-only',
           externalRoleName: externalRoleArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -609,7 +609,7 @@ describe('S3DataSetStoragePlugin', () => {
           accessLevel: 'read-write',
           externalRoleName: externalRoleArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -655,7 +655,7 @@ describe('S3DataSetStoragePlugin', () => {
           accessLevel: 'read-only',
           externalRoleName: externalRoleArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -715,7 +715,7 @@ describe('S3DataSetStoragePlugin', () => {
           externalRoleName: externalRoleArn,
           vpcId
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -775,7 +775,7 @@ describe('S3DataSetStoragePlugin', () => {
           accessLevel: 'read-only',
           externalRoleName: externalRoleArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -821,7 +821,7 @@ describe('S3DataSetStoragePlugin', () => {
           externalRoleName: externalRoleArn,
           kmsKeyArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -887,7 +887,7 @@ describe('S3DataSetStoragePlugin', () => {
           externalRoleName: externalRoleArn,
           kmsKeyArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -970,7 +970,7 @@ describe('S3DataSetStoragePlugin', () => {
           externalRoleName: externalRoleArn,
           kmsKeyArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,
@@ -1033,7 +1033,7 @@ describe('S3DataSetStoragePlugin', () => {
           externalRoleName: externalRoleArn,
           kmsKeyArn
         })
-      ).resolves.toMatchObject<AddStorageExternalEndpointResponse>({
+      ).resolves.toStrictEqual<AddStorageExternalEndpointResponse>({
         data: {
           connections: {
             endPointUrl: `s3://${accessPointArn}`,

--- a/workbench-core/datasets/src/wbcDataSetsAuthorizationPlugin.test.ts
+++ b/workbench-core/datasets/src/wbcDataSetsAuthorizationPlugin.test.ts
@@ -447,7 +447,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
 
       await expect(
         plugin.removeAllAccessPermissions(dataSetId, authenticatedUser)
-      ).resolves.toMatchObject<PermissionsResponse>({
+      ).resolves.toStrictEqual<PermissionsResponse>({
         data: {
           dataSetId: getAccessPermission.dataSetId,
           permissions: [
@@ -463,7 +463,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
 
       await expect(
         plugin.removeAllAccessPermissions(dataSetId, authenticatedUser)
-      ).resolves.toMatchObject<PermissionsResponse>({
+      ).resolves.toStrictEqual<PermissionsResponse>({
         data: {
           dataSetId: getAccessPermission.dataSetId,
           permissions: [
@@ -491,7 +491,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
             }
           };
         });
-      await expect(plugin.removeAllAccessPermissions(dataSetId, authenticatedUser)).resolves.toMatchObject({
+      await expect(plugin.removeAllAccessPermissions(dataSetId, authenticatedUser)).resolves.toStrictEqual({
         data: {
           dataSetId,
           permissions: []
@@ -564,7 +564,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
             subjectType: dataSetSubjectType
           }
         ])
-      ).toMatchObject([
+      ).toStrictEqual([
         {
           data: {
             dataSetId: dataSetId,
@@ -605,7 +605,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
             subjectType: dataSetSubjectType
           }
         ])
-      ).toMatchObject([
+      ).toStrictEqual([
         {
           data: {
             dataSetId: dataSetId,
@@ -641,7 +641,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
             subjectType: dataSetSubjectType
           }
         ])
-      ).toMatchObject([
+      ).toStrictEqual([
         {
           data: {
             dataSetId: dataSetId,
@@ -671,7 +671,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
 
       await expect(
         plugin.getAccessPermissions(getAccessPermission)
-      ).resolves.toMatchObject<PermissionsResponse>({
+      ).resolves.toStrictEqual<PermissionsResponse>({
         data: {
           dataSetId: getAccessPermission.dataSetId,
           permissions: [
@@ -687,7 +687,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
 
       await expect(
         plugin.getAccessPermissions(getAccessPermission)
-      ).resolves.toMatchObject<PermissionsResponse>({
+      ).resolves.toStrictEqual<PermissionsResponse>({
         data: {
           dataSetId: getAccessPermission.dataSetId,
           permissions: [
@@ -724,7 +724,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
             }
           };
         });
-      await expect(plugin.getAccessPermissions(getAccessPermission)).resolves.toMatchObject({
+      await expect(plugin.getAccessPermissions(getAccessPermission)).resolves.toStrictEqual({
         data: {
           dataSetId,
           permissions: []
@@ -741,7 +741,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
 
       await expect(
         plugin.getAllDataSetAccessPermissions(dataSetId)
-      ).resolves.toMatchObject<PermissionsResponse>({
+      ).resolves.toStrictEqual<PermissionsResponse>({
         data: {
           dataSetId: getAccessPermission.dataSetId,
           permissions: [
@@ -758,7 +758,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
 
       await expect(
         plugin.getAllDataSetAccessPermissions(dataSetId, undefined, 1)
-      ).resolves.toMatchObject<PermissionsResponse>({
+      ).resolves.toStrictEqual<PermissionsResponse>({
         data: {
           dataSetId: getAccessPermission.dataSetId,
           permissions: [
@@ -776,7 +776,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
 
       await expect(
         plugin.getAllDataSetAccessPermissions(dataSetId, undefined, 1)
-      ).resolves.toMatchObject<PermissionsResponse>({
+      ).resolves.toStrictEqual<PermissionsResponse>({
         data: {
           dataSetId: getAccessPermission.dataSetId,
           permissions: [
@@ -794,7 +794,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
 
       await expect(
         plugin.getAllDataSetAccessPermissions(dataSetId)
-      ).resolves.toMatchObject<PermissionsResponse>({
+      ).resolves.toStrictEqual<PermissionsResponse>({
         data: {
           dataSetId: getAccessPermission.dataSetId,
           permissions: [
@@ -822,7 +822,7 @@ describe('wbcDataSetsAuthorizationPlugin tests', () => {
             }
           };
         });
-      await expect(plugin.getAllDataSetAccessPermissions(dataSetId)).resolves.toMatchObject({
+      await expect(plugin.getAllDataSetAccessPermissions(dataSetId)).resolves.toStrictEqual({
         data: {
           dataSetId,
           permissions: []

--- a/workbench-core/datasets/src/wbcDataSetsAuthorizationPlugin.ts
+++ b/workbench-core/datasets/src/wbcDataSetsAuthorizationPlugin.ts
@@ -144,10 +144,12 @@ export class WbcDataSetsAuthorizationPlugin implements DataSetsAuthorizationPlug
           dataSetId: datasetId,
           permissions: []
         },
-        pageToken: identityResponse.paginationToken
+        ...(identityResponse.paginationToken ? { pageToken: identityResponse.paginationToken } : {})
       };
     }
-    permissionsResponse[0].pageToken = identityResponse.paginationToken;
+    if (identityResponse.paginationToken) {
+      permissionsResponse[0].pageToken = identityResponse.paginationToken;
+    }
     return permissionsResponse[0];
   }
 

--- a/workbench-core/environments/src/services/environmentService.test.ts
+++ b/workbench-core/environments/src/services/environmentService.test.ts
@@ -975,7 +975,7 @@ describe('EnvironmentService', () => {
 
       // CHECK
       const updateCall = ddbMock.commandCalls(UpdateItemCommand)[0];
-      expect(updateCall.args[0].input).toMatchObject({
+      expect(updateCall.args[0].input).toStrictEqual({
         TableName: tableName,
         Key: {
           pk: {

--- a/workbench-core/example/infrastructure/integration-tests/tests/audit/auditEntry.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/audit/auditEntry.test.ts
@@ -89,7 +89,7 @@ describe('Audit service integration tests', () => {
     };
     const response = await newAdminSession.resources.auditEntry.isAuditEntryComplete(auditEntry);
     expect(response.status).toBe(200);
-    expect(response.data).toMatchObject({
+    expect(response.data).toStrictEqual({
       isComplete: false
     });
   });
@@ -102,7 +102,7 @@ describe('Audit service integration tests', () => {
     };
     const response = await newAdminSession.resources.auditEntry.isAuditEntryComplete(auditEntry);
     expect(response.status).toBe(200);
-    expect(response.data).toMatchObject({
+    expect(response.data).toStrictEqual({
       isComplete: true
     });
   });
@@ -113,7 +113,7 @@ describe('Audit service integration tests', () => {
     async (randomObject) => {
       const response = await newAdminSession.resources.auditEntry.isAuditEntryComplete(randomObject);
       expect(response.status).toBe(200);
-      expect(response.data).toMatchObject({
+      expect(response.data).toStrictEqual({
         isComplete: false
       });
     }

--- a/workbench-core/example/infrastructure/integration-tests/tests/authorization/routeProtection.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/authorization/routeProtection.test.ts
@@ -148,7 +148,7 @@ describe('Static authorization integration tests', () => {
         method
       });
       expect(status).toBe(200);
-      expect(data).toMatchObject({
+      expect(data).toStrictEqual({
         ignored: true
       });
     });
@@ -161,7 +161,7 @@ describe('Static authorization integration tests', () => {
         method
       });
       expect(status).toBe(200);
-      expect(data).toMatchObject({
+      expect(data).toStrictEqual({
         ignored: false
       });
     });

--- a/workbench-core/example/infrastructure/integration-tests/tests/datasets/accessPermissions.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/datasets/accessPermissions.test.ts
@@ -52,7 +52,7 @@ describe('DataSets access permissions integration tests', () => {
             accessLevel: 'read-only'
           }
         })
-      ).resolves.toMatchObject({
+      ).resolves.toStrictEqual({
         data: {
           dataSetId: dataSetId,
           permissions: [
@@ -79,7 +79,7 @@ describe('DataSets access permissions integration tests', () => {
             accessLevel: 'read-write'
           }
         })
-      ).resolves.toMatchObject({
+      ).resolves.toStrictEqual({
         data: {
           dataSetId: dataSetId,
           permissions: [
@@ -103,7 +103,7 @@ describe('DataSets access permissions integration tests', () => {
             accessLevel: 'read-only'
           }
         })
-      ).resolves.toMatchObject({
+      ).resolves.toStrictEqual({
         data: {
           dataSetId: dataSetId,
           permissions: [
@@ -196,7 +196,7 @@ describe('DataSets access permissions integration tests', () => {
           accessLevel: 'read-write'
         }
       });
-      await expect(dataSet.getAllAccess()).resolves.toMatchObject({
+      await expect(dataSet.getAllAccess()).resolves.toStrictEqual({
         data: {
           dataSetId: dataSetId,
           permissions: [
@@ -232,7 +232,7 @@ describe('DataSets access permissions integration tests', () => {
           accessLevel: 'read-only'
         }
       });
-      // using await expect(...).toMatchObject(...) requires permissions order to be
+      // using await expect(...).toStrictEqual(...) requires permissions order to be
       // deterministic. This is not.
       const response: PermissionsResponse = await dataSet.getAllAccess();
       expect(response.data).toBeDefined();
@@ -242,11 +242,11 @@ describe('DataSets access permissions integration tests', () => {
       const defaultPermission = response.data.permissions.filter(
         (p: DataSetPermission) => p.identity === permissions[0].identity
       );
-      expect(defaultPermission).toMatchObject(permissions);
+      expect(defaultPermission).toStrictEqual(permissions);
       const userPermission = response.data.permissions.filter(
         (p: DataSetPermission) => p.identity === userId
       );
-      expect(userPermission).toMatchObject([
+      expect(userPermission).toStrictEqual([
         {
           identityType: 'USER',
           identity: userId,
@@ -256,7 +256,7 @@ describe('DataSets access permissions integration tests', () => {
       const groupPermission = response.data.permissions.filter(
         (p: DataSetPermission) => p.identity === groupId
       );
-      expect(groupPermission).toMatchObject([
+      expect(groupPermission).toStrictEqual([
         {
           identityType: 'GROUP',
           identity: groupId,
@@ -286,7 +286,7 @@ describe('DataSets access permissions integration tests', () => {
           accessLevel: 'read-only'
         }
       });
-      // using await expect(...).toMatchObject(...) requires permissions order to be
+      // using await expect(...).toStrictEqual(...) requires permissions order to be
       // deterministic. This is not.
       const response: PermissionsResponse = await dataSet.getAllAccess({
         pageSize: '2'
@@ -309,9 +309,9 @@ describe('DataSets access permissions integration tests', () => {
       const defaultPermission = allPermissions.filter(
         (p: DataSetPermission) => p.identity === permissions[0].identity
       );
-      expect(defaultPermission).toMatchObject(permissions);
+      expect(defaultPermission).toStrictEqual(permissions);
       const userPermission = allPermissions.filter((p: DataSetPermission) => p.identity === userId);
-      expect(userPermission).toMatchObject([
+      expect(userPermission).toStrictEqual([
         {
           identityType: 'USER',
           identity: userId,
@@ -319,7 +319,7 @@ describe('DataSets access permissions integration tests', () => {
         }
       ]);
       const groupPermission = allPermissions.filter((p: DataSetPermission) => p.identity === groupId);
-      expect(groupPermission).toMatchObject([
+      expect(groupPermission).toStrictEqual([
         {
           identityType: 'GROUP',
           identity: groupId,
@@ -356,7 +356,7 @@ describe('DataSets access permissions integration tests', () => {
           accessLevel: 'read-write'
         }
       });
-      await expect(dataSet.getAccess('GROUP', groupId)).resolves.toMatchObject({
+      await expect(dataSet.getAccess('GROUP', groupId)).resolves.toStrictEqual({
         data: {
           dataSetId: dataSetId,
           permissions: [
@@ -380,7 +380,7 @@ describe('DataSets access permissions integration tests', () => {
           accessLevel: 'read-only'
         }
       });
-      await expect(dataSet.getAccess('USER', userId)).resolves.toMatchObject({
+      await expect(dataSet.getAccess('USER', userId)).resolves.toStrictEqual({
         data: {
           dataSetId: dataSetId,
           permissions: [
@@ -416,7 +416,7 @@ describe('DataSets access permissions integration tests', () => {
             accessLevel: 'read-only'
           }
         })
-      ).resolves.toMatchObject({
+      ).resolves.toStrictEqual({
         data: {
           dataSetId: dataSetId,
           permissions: [
@@ -449,7 +449,7 @@ describe('DataSets access permissions integration tests', () => {
             accessLevel: 'read-write'
           }
         })
-      ).resolves.toMatchObject({
+      ).resolves.toStrictEqual({
         data: {
           dataSetId: dataSetId,
           permissions: [
@@ -480,7 +480,7 @@ describe('DataSets access permissions integration tests', () => {
             accessLevel: 'read-only'
           }
         })
-      ).resolves.toMatchObject({
+      ).resolves.toStrictEqual({
         data: {
           dataSetId: dataSetId,
           permissions: [

--- a/workbench-core/example/infrastructure/integration-tests/tests/datasets/byob.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/datasets/byob.test.ts
@@ -3,7 +3,6 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { AddDataSetExternalEndpointResponse } from '@aws/workbench-core-datasets';
 import { v4 as uuidv4 } from 'uuid';
 import ClientSession from '../../support/clientSession';
 import { DatasetHelper } from '../../support/complex/datasetHelper';
@@ -49,7 +48,15 @@ describe('datasets byob integration test', () => {
 
       const { data } = await adminSession.resources.datasets.create(byobCreateParams);
 
-      expect(data).toMatchObject(expected);
+      expect(data).toStrictEqual({
+        ...expected,
+        createdAt: expect.any(String),
+        id: expect.any(String),
+        name: expect.any(String),
+        path: expect.any(String),
+        storageType: expect.any(String),
+        permissions: expect.any(Array)
+      });
     });
   });
 
@@ -73,20 +80,18 @@ describe('datasets byob integration test', () => {
       });
       const dataset = adminSession.resources.datasets.children.get(datasetData.id) as Dataset;
 
-      const response = await dataset.share({
+      const { data } = await dataset.share({
         userId: userData.id,
         region: hostRegion,
         roleToAssume
       });
 
-      expect(response).toMatchObject<AddDataSetExternalEndpointResponse>({
-        data: {
-          mountObject: {
-            name: dataset.storagePath,
-            bucket: expect.stringMatching(accessPointS3AliasRegExp),
-            prefix: dataset.storagePath,
-            endpointId: expect.stringMatching(endpointIdRegExp)
-          }
+      expect(data).toStrictEqual({
+        mountObject: {
+          name: dataset.storagePath,
+          bucket: expect.stringMatching(accessPointS3AliasRegExp),
+          prefix: dataset.storagePath,
+          endpointId: expect.stringMatching(endpointIdRegExp)
         }
       });
     });

--- a/workbench-core/example/infrastructure/integration-tests/tests/datasets/create.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/datasets/create.test.ts
@@ -3,7 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { AddDataSetExternalEndpointResponse, DataSetPermission } from '@aws/workbench-core-datasets';
+import { DataSetPermission } from '@aws/workbench-core-datasets';
 import { v4 as uuidv4 } from 'uuid';
 import ClientSession from '../../support/clientSession';
 import { DatasetHelper } from '../../support/complex/datasetHelper';
@@ -60,7 +60,7 @@ describe('datasets create integration test', () => {
       });
 
       expect(response.data.id).toBeDefined();
-      expect(response.data.permissions).toMatchObject<DataSetPermission[]>([
+      expect(response.data.permissions).toStrictEqual<DataSetPermission[]>([
         {
           identity: groupId,
           identityType: 'GROUP',
@@ -75,7 +75,7 @@ describe('datasets create integration test', () => {
         owner: groupId,
         ownerType: 'GROUP'
       });
-      expect(response.data.permissions).toMatchObject<DataSetPermission[]>([
+      expect(response.data.permissions).toStrictEqual<DataSetPermission[]>([
         {
           identity: groupId,
           identityType: 'GROUP',
@@ -121,16 +121,14 @@ describe('datasets create integration test', () => {
           accessLevel: 'read-only'
         }
       });
-      const response = await dataset.share({ userId });
+      const { data } = await dataset.share({ userId });
 
-      expect(response).toMatchObject<AddDataSetExternalEndpointResponse>({
-        data: {
-          mountObject: {
-            name: dataset.storagePath,
-            bucket: expect.stringMatching(accessPointS3AliasRegExp),
-            prefix: dataset.storagePath,
-            endpointId: expect.stringMatching(endpointIdRegExp)
-          }
+      expect(data).toStrictEqual({
+        mountObject: {
+          name: dataset.storagePath,
+          bucket: expect.stringMatching(accessPointS3AliasRegExp),
+          prefix: dataset.storagePath,
+          endpointId: expect.stringMatching(endpointIdRegExp)
         }
       });
 
@@ -139,7 +137,7 @@ describe('datasets create integration test', () => {
       const metadata = await DatasetHelper.getddbRecords(
         mainAwsService,
         dataset.id,
-        response.data.mountObject.endpointId
+        data.mountObject.endpointId
       );
       expect(metadata.authenticatedUser).toBeUndefined();
     });
@@ -196,16 +194,14 @@ describe('datasets create integration test', () => {
           accessLevel: 'read-only'
         }
       });
-      const response = await dataset.share({ groupId });
+      const { data } = await dataset.share({ groupId });
 
-      expect(response).toMatchObject<AddDataSetExternalEndpointResponse>({
-        data: {
-          mountObject: {
-            name: dataset.storagePath,
-            bucket: expect.stringMatching(accessPointS3AliasRegExp),
-            prefix: dataset.storagePath,
-            endpointId: expect.stringMatching(endpointIdRegExp)
-          }
+      expect(data).toStrictEqual({
+        mountObject: {
+          name: dataset.storagePath,
+          bucket: expect.stringMatching(accessPointS3AliasRegExp),
+          prefix: dataset.storagePath,
+          endpointId: expect.stringMatching(endpointIdRegExp)
         }
       });
 
@@ -214,7 +210,7 @@ describe('datasets create integration test', () => {
       const metadata = await DatasetHelper.getddbRecords(
         mainAwsService,
         dataset.id,
-        response.data.mountObject.endpointId
+        data.mountObject.endpointId
       );
       expect(metadata.authenticatedUser).toBeUndefined();
     });

--- a/workbench-core/example/infrastructure/integration-tests/tests/datasets/delete.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/datasets/delete.test.ts
@@ -47,7 +47,7 @@ describe('datasets delete integration test', () => {
       const deleteResponse = await adminSession.resources.datasets.children.get(dataSet.id!)!.delete();
       const deleted: DataSet = deleteResponse.data;
 
-      expect(deleted).toMatchObject<DataSet>(dataSet);
+      expect(deleted).toStrictEqual<DataSet>(dataSet);
 
       await expect(adminSession.resources.datasets.get({ id: dataSet.id! })).rejects.toThrowError(
         new HttpError(404, 'Not Found')

--- a/workbench-core/example/infrastructure/integration-tests/tests/datasets/get.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/datasets/get.test.ts
@@ -46,7 +46,7 @@ describe('datasets get integration test', () => {
       const endpoint = dataset.children.get(endpointData.mountObject.endpointId)!;
       const { data } = await endpoint.getMountObject();
 
-      expect(data).toMatchObject<GetDataSetMountPointResponse>(endpointData);
+      expect(data).toStrictEqual<GetDataSetMountPointResponse>(endpointData);
     });
 
     it('throws when getting the mount object of a dataset which does not exist', async () => {

--- a/workbench-core/example/infrastructure/integration-tests/tests/datasets/iamRoles.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/datasets/iamRoles.test.ts
@@ -45,7 +45,7 @@ describe('datasets IAM tests', () => {
       const expected =
         '{"Type":"AWS::IAM::Role","Properties":{"RoleName":"roleName","AssumeRolePolicyDocument":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"assumingAwsAccountId"},"Action":["sts:AssumeRole"],"Condition":{"StringEquals":{"sts:ExternalId":"externalId"}}}]},"Description":"A role that allows the datasets package to perform basic actions","Policies":[{"PolicyName":"dataset-base-permissions","PolicyDocument":{"Version":"2012-10-17","Statement":[{"Sid":"AccessPointCreationDeletion","Effect":"Allow","Action":["s3:CreateAccessPoint","s3:DeleteAccessPoint","s3:GetAccessPointPolicy","s3:PutAccessPointPolicy"],"Resource":["arn:aws:s3:awsBucketRegion:awsAccountId:accesspoint/*"]},{"Sid":"CreateRemoveAccessPointDelegation","Effect":"Allow","Action":["s3:GetBucketPolicy","s3:PutBucketPolicy"],"Resource":["s3BucketArn"]},{"Sid":"ListTopLevelFolders","Effect":"Allow","Action":"s3:ListBucket","Resource":["s3BucketArn"],"Condition":{"StringEquals":{"s3:prefix":[""],"s3:delimiter":["/"]}}}]}}]}}';
       const response = await adminSession.resources.datasets.createRole(validRequest);
-      expect(JSON.parse(response.data.iamRoleString)).toMatchObject(JSON.parse(expected));
+      expect(JSON.parse(response.data.iamRoleString)).toStrictEqual(JSON.parse(expected));
     });
 
     it('returns an IAM role with KMS permissions when the KMS key ARN is provided', async () => {
@@ -55,7 +55,7 @@ describe('datasets IAM tests', () => {
         ...validRequest,
         kmsKeyArn: 'kmsKeyArn'
       });
-      expect(JSON.parse(response.data.iamRoleString)).toMatchObject(JSON.parse(expected));
+      expect(JSON.parse(response.data.iamRoleString)).toStrictEqual(JSON.parse(expected));
     });
 
     it('throws when the roleName parameter in the request body is missing', async () => {
@@ -205,7 +205,7 @@ describe('datasets IAM tests', () => {
       const expected =
         '{"Type":"AWS::IAM::Role","Properties":{"RoleName":"roleName","AssumeRolePolicyDocument":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"assumingAwsAccountId"},"Action":["sts:AssumeRole"],"Condition":{"StringEquals":{"sts:ExternalId":"externalId"}}}]},"Description":"A role that allows the datasets package to perform basic actions","Policies":[{"PolicyName":"dataset-base-permissions","PolicyDocument":{"Version":"2012-10-17","Statement":[{"Sid":"AccessPointCreationDeletion","Effect":"Allow","Action":["s3:CreateAccessPoint","s3:DeleteAccessPoint","s3:GetAccessPointPolicy","s3:PutAccessPointPolicy"],"Resource":["arn:aws:s3:awsBucketRegion:awsAccountId:accesspoint/*"]},{"Sid":"CreateRemoveAccessPointDelegation","Effect":"Allow","Action":["s3:GetBucketPolicy","s3:PutBucketPolicy"],"Resource":["s3BucketArn"]},{"Sid":"ListTopLevelFolders","Effect":"Allow","Action":"s3:ListBucket","Resource":["s3BucketArn"],"Condition":{"StringEquals":{"s3:prefix":[""],"s3:delimiter":["/"]}}}]}},{"PolicyName":"datasetPrefix-permissions","PolicyDocument":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:ListBucket","Resource":["accessPointArn"],"Condition":{"StringLike":{"s3:prefix":"datasetPrefix/*"}}},{"Effect":"Allow","Action":["s3:GetObject","s3:PutObject"],"Resource":"accessPointArn/object/datasetPrefix/*"}]}}]}}';
       const response = await adminSession.resources.datasets.updateRole(validRequest);
-      expect(JSON.parse(response.data.iamRoleString)).toMatchObject(JSON.parse(expected));
+      expect(JSON.parse(response.data.iamRoleString)).toStrictEqual(JSON.parse(expected));
     });
 
     it('throws when the roleString doesnt represent a valid IAM role', async () => {

--- a/workbench-core/example/infrastructure/integration-tests/tests/dynamicAuthorization/group.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/dynamicAuthorization/group.test.ts
@@ -99,7 +99,7 @@ describe('dynamic authorization group integration tests', () => {
 
       const { data } = await adminSession.resources.groups.getUserGroups(userData.id);
 
-      expect(data).toMatchObject({ groupIds: [groupData.groupId] });
+      expect(data).toStrictEqual({ groupIds: [groupData.groupId] });
     });
 
     it('returns a 404 error when the user doesnt exist', async () => {
@@ -130,7 +130,7 @@ describe('dynamic authorization group integration tests', () => {
       await adminSession.resources.groups.group(groupData.groupId).addUser({ userId: userData.id });
       const { data } = await adminSession.resources.groups.group(groupData.groupId).getGroupUsers();
 
-      expect(data).toMatchObject({ userIds: [userData.id] });
+      expect(data).toStrictEqual({ userIds: [userData.id] });
     });
 
     it('returns a 404 error when the Group doesnt exist', async () => {
@@ -155,7 +155,7 @@ describe('dynamic authorization group integration tests', () => {
       const { data } = await adminSession.resources.groups.group(createGroupData.groupId).addUser({
         userId: createUserData.id
       });
-      expect(data).toMatchObject({ groupId: createGroupData.groupId, userId: createUserData.id });
+      expect(data).toStrictEqual({ groupId: createGroupData.groupId, userId: createUserData.id });
     });
 
     test.each([{}, { userId: 123 }, { userId: 'testUserId', badParam: 'bad' }])(
@@ -211,14 +211,14 @@ describe('dynamic authorization group integration tests', () => {
       const { data } = await adminSession.resources.groups
         .group(groupData.groupId)
         .isUserAssigned(userData.id);
-      expect(data).toMatchObject({ isAssigned: true });
+      expect(data).toStrictEqual({ isAssigned: true });
     });
 
     it('returns false when the user is not in the group', async () => {
       const { data: userData } = await adminSession.resources.users.create(user);
 
       const { data } = await adminSession.resources.groups.group('fakeGroupId').isUserAssigned(userData.id);
-      expect(data).toMatchObject({ isAssigned: false });
+      expect(data).toStrictEqual({ isAssigned: false });
     });
 
     it('returns a 404 error when the user doesnt exist', async () => {
@@ -252,7 +252,7 @@ describe('dynamic authorization group integration tests', () => {
       const { data } = await adminSession.resources.groups
         .group(groupData.groupId)
         .removeUser({ userId: userData.id });
-      expect(data).toMatchObject({ groupId: groupData.groupId, userId: userData.id });
+      expect(data).toStrictEqual({ groupId: groupData.groupId, userId: userData.id });
     });
 
     test.each([{}, { userId: 123 }, { userId: 'testUserId', badParam: 'bad' }])(
@@ -300,7 +300,7 @@ describe('dynamic authorization group integration tests', () => {
 
       const { data } = await group.delete();
 
-      expect(data).toMatchObject({ groupId });
+      expect(data).toStrictEqual({ groupId });
     });
 
     it('returns a 404 error when trying to delete a group that does not exists', async () => {
@@ -318,7 +318,7 @@ describe('dynamic authorization group integration tests', () => {
         groupId = data.groupId;
       }
       const { data } = await adminSession.resources.groups.group(groupId).doesGroupExist();
-      expect(data).toMatchObject({
+      expect(data).toStrictEqual({
         exist: groupExists
       });
     });

--- a/workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/users/activateDeactivateUser.test.ts
@@ -16,6 +16,11 @@ describe('userManagement activate/deactivate user integration test', () => {
   const setup: Setup = new Setup();
   let adminSession: ClientSession;
   let userId: string;
+  const mockUserData = {
+    firstName: 'Test',
+    lastName: 'User',
+    email: `success+activate-deactivate-user-${uuidv4()}@simulator.amazonses.com`
+  };
 
   beforeEach(() => {
     expect.hasAssertions();
@@ -24,11 +29,7 @@ describe('userManagement activate/deactivate user integration test', () => {
   beforeAll(async () => {
     adminSession = await setup.getDefaultAdminSession();
 
-    const { data } = await adminSession.resources.users.create({
-      firstName: 'Test',
-      lastName: 'User',
-      email: `success+activate-deactivate-user-${uuidv4()}@simulator.amazonses.com`
-    });
+    const { data } = await adminSession.resources.users.create(mockUserData);
     userId = data.id;
   });
 
@@ -42,7 +43,10 @@ describe('userManagement activate/deactivate user integration test', () => {
 
     const { data: activeUser } = await adminSession.resources.users.user(userId).get();
 
-    expect(activeUser).toMatchObject({
+    expect(activeUser).toStrictEqual({
+      ...mockUserData,
+      id: expect.any(String),
+      roles: [],
       status: Status.ACTIVE
     });
   });
@@ -53,7 +57,10 @@ describe('userManagement activate/deactivate user integration test', () => {
 
     const { data: inactiveUser } = await adminSession.resources.users.user(userId).get();
 
-    expect(inactiveUser).toMatchObject({
+    expect(inactiveUser).toStrictEqual({
+      ...mockUserData,
+      id: expect.any(String),
+      roles: [],
       status: Status.INACTIVE
     });
   });
@@ -64,7 +71,10 @@ describe('userManagement activate/deactivate user integration test', () => {
 
     const { data: activeUser } = await adminSession.resources.users.user(userId).get();
 
-    expect(activeUser).toMatchObject({
+    expect(activeUser).toStrictEqual({
+      ...mockUserData,
+      id: expect.any(String),
+      roles: [],
       status: Status.ACTIVE
     });
   });
@@ -75,8 +85,11 @@ describe('userManagement activate/deactivate user integration test', () => {
 
     const { data: activeUser } = await adminSession.resources.users.user(userId).get();
 
-    expect(activeUser).toMatchObject({
-      status: Status.INACTIVE
+    expect(activeUser).toStrictEqual({
+      id: expect.any(String),
+      ...mockUserData,
+      status: Status.INACTIVE,
+      roles: []
     });
   });
 

--- a/workbench-core/example/infrastructure/integration-tests/tests/users/createUser.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/users/createUser.test.ts
@@ -35,8 +35,9 @@ describe('userManagement create user integration test', () => {
   it('should return a created user', async () => {
     const response = await adminSession.resources.users.create(user);
 
-    expect(response.data).toMatchObject({
+    expect(response.data).toStrictEqual({
       ...user,
+      id: expect.any(String),
       status: Status.ACTIVE,
       roles: []
     });

--- a/workbench-core/example/infrastructure/integration-tests/tests/users/getUserRoles.test.ts
+++ b/workbench-core/example/infrastructure/integration-tests/tests/users/getUserRoles.test.ts
@@ -43,7 +43,7 @@ describe('userManagement get user roles integration test', () => {
 
     const { data } = await adminSession.resources.users.user(userData.id).getRoles();
 
-    expect(data).toMatchObject({});
+    expect(data).toStrictEqual([expect.any(String)]);
   });
 
   it('throws a 404 error when the user doesnt exist', async () => {

--- a/workbench-core/logging/src/plugins/winstonPlugin.test.ts
+++ b/workbench-core/logging/src/plugins/winstonPlugin.test.ts
@@ -70,7 +70,7 @@ describe('WinstonPlugin tests', () => {
 
       logger.setDefaultMetadata(metadata as LogMessageObject);
 
-      expect(logger['_logger'].defaultMeta).toMatchObject({ meta: metadata }); // nosemgrep
+      expect(logger['_logger'].defaultMeta).toStrictEqual({ meta: metadata }); // nosemgrep
     }
   );
 

--- a/workbench-core/user-management/src/plugins/cognitoUserManagementPlugin.test.ts
+++ b/workbench-core/user-management/src/plugins/cognitoUserManagementPlugin.test.ts
@@ -94,7 +94,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.getUser(userInfo.id);
 
-      expect(user).toMatchObject<User>({
+      expect(user).toStrictEqual<User>({
         ...userInfo,
         roles
       });
@@ -114,7 +114,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.getUser(userInfo.id);
 
-      expect(user).toMatchObject<User>({
+      expect(user).toStrictEqual<User>({
         ...userInfo,
         firstName: '',
         roles
@@ -135,7 +135,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.getUser(userInfo.id);
 
-      expect(user).toMatchObject<User>({
+      expect(user).toStrictEqual<User>({
         ...userInfo,
         lastName: '',
         roles
@@ -156,7 +156,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.getUser(userInfo.id);
 
-      expect(user).toMatchObject<User>({
+      expect(user).toStrictEqual<User>({
         ...userInfo,
         email: '',
         roles
@@ -178,7 +178,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.getUser(userInfo.id);
 
-      expect(user).toMatchObject<User>({
+      expect(user).toStrictEqual<User>({
         ...userInfo,
         status: Status.INACTIVE,
         roles
@@ -199,7 +199,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.getUser(userInfo.id);
 
-      expect(user).toMatchObject<User>({
+      expect(user).toStrictEqual<User>({
         ...userInfo,
         status: Status.INACTIVE,
         roles
@@ -219,7 +219,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.getUser(userInfo.id);
 
-      expect(user).toMatchObject<User>({
+      expect(user).toStrictEqual<User>({
         ...userInfo,
         roles: []
       });
@@ -233,7 +233,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.getUser(userInfo.id);
 
-      expect(user).toMatchObject<User>({
+      expect(user).toStrictEqual<User>({
         ...userInfo,
         firstName: '',
         lastName: '',
@@ -255,7 +255,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.getUser(userInfo.id);
 
-      expect(user).toMatchObject<User>({
+      expect(user).toStrictEqual<User>({
         ...userInfo,
         roles: []
       });
@@ -310,7 +310,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const userRoles = await plugin.getUserRoles(userInfo.id);
 
-      expect(userRoles).toMatchObject([...roles]);
+      expect(userRoles).toStrictEqual([...roles]);
     });
 
     it('should return an empty array for the Users roles when no roles are assigned to it', async () => {
@@ -318,7 +318,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const userRoles = await plugin.getUserRoles(userInfo.id);
 
-      expect(userRoles).toMatchObject([]);
+      expect(userRoles).toStrictEqual([]);
     });
 
     it('should throw IdpUnavailableError when Cognito is unavailable', async () => {
@@ -384,7 +384,7 @@ describe('CognitoUserManagementPlugin tests', () => {
 
       const user = await plugin.createUser(userInfo);
 
-      expect(user).toMatchObject({ ...userInfo, roles: [] });
+      expect(user).toStrictEqual({ ...userInfo, roles: [] });
     });
 
     it('should throw IdpUnavailableError when Cognito is unavailable', async () => {
@@ -714,7 +714,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const users = await plugin.listUsers();
 
       expect(users.length).toBe(1);
-      expect(users).toMatchObject([{ ...userInfo, roles }]);
+      expect(users).toStrictEqual([{ ...userInfo, roles }]);
     });
 
     it('should return an empty array for user.role for users with no groups', async () => {
@@ -736,7 +736,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const users = await plugin.listUsers();
 
       expect(users.length).toBe(1);
-      expect(users).toMatchObject([{ ...userInfo, roles: [] }]);
+      expect(users).toStrictEqual([{ ...userInfo, roles: [] }]);
     });
 
     it('should return an empty array when no users are in the user pool', async () => {
@@ -745,7 +745,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const users = await plugin.listUsers();
 
       expect(users.length).toBe(0);
-      expect(users).toMatchObject<string[]>([]);
+      expect(users).toStrictEqual<string[]>([]);
     });
 
     it('should return an empty array when the users dont have user ids', async () => {
@@ -767,7 +767,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const users = await plugin.listUsers();
 
       expect(users.length).toBe(0);
-      expect(users).toMatchObject([]);
+      expect(users).toStrictEqual([]);
     });
 
     it('should populate missing values with empty strings', async () => {
@@ -777,7 +777,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const users = await plugin.listUsers();
 
       expect(users.length).toBe(1);
-      expect(users).toMatchObject<User[]>([
+      expect(users).toStrictEqual<User[]>([
         { id: userInfo.id, firstName: '', lastName: '', email: '', status: Status.INACTIVE, roles: [] }
       ]);
     });
@@ -820,7 +820,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const users = await plugin.listUsersForRole(roles[0]);
 
       expect(users.length).toBe(1);
-      expect(users).toMatchObject<string[]>([userInfo.id]);
+      expect(users).toStrictEqual<string[]>([userInfo.id]);
     });
 
     it('should return an empty array when no users are in group', async () => {
@@ -829,7 +829,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const users = await plugin.listUsersForRole(roles[0]);
 
       expect(users.length).toBe(0);
-      expect(users).toMatchObject<string[]>([]);
+      expect(users).toStrictEqual<string[]>([]);
     });
 
     it('should return an empty array when the users dont have user ids', async () => {
@@ -838,7 +838,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const users = await plugin.listUsersForRole(roles[0]);
 
       expect(users.length).toBe(0);
-      expect(users).toMatchObject<string[]>([]);
+      expect(users).toStrictEqual<string[]>([]);
     });
 
     it('should throw IdpUnavailableError when Cognito is unavailable', async () => {
@@ -895,7 +895,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const groups = await plugin.listRoles();
 
       expect(groups.length).toBe(roles.length);
-      expect(groups).toMatchObject<string[]>(roles);
+      expect(groups).toStrictEqual<string[]>(roles);
     });
 
     it('should return an empty array when no groups are in the user pool', async () => {
@@ -904,7 +904,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const groups = await plugin.listRoles();
 
       expect(groups.length).toBe(0);
-      expect(groups).toMatchObject<string[]>([]);
+      expect(groups).toStrictEqual<string[]>([]);
     });
 
     it('should return an empty array when the groups dont have names', async () => {
@@ -913,7 +913,7 @@ describe('CognitoUserManagementPlugin tests', () => {
       const groups = await plugin.listRoles();
 
       expect(groups.length).toBe(0);
-      expect(groups).toMatchObject<string[]>([]);
+      expect(groups).toStrictEqual<string[]>([]);
     });
 
     it('should throw IdpUnavailableError when Cognito is unavailable', async () => {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This PR changes currently used `expect` method `toMatchObject` to more preferred `toStrictEqual`.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.