### PR TITLE
chore: validate environment belongs to project on APIs

### DIFF
--- a/common/changes/@aws/swb-app/farandac-validate-env-project_2023-04-06-15-57.json
+++ b/common/changes/@aws/swb-app/farandac-validate-env-project_2023-04-06-15-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "validate project on environment get API",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/solutions/swb-reference/integration-tests/tests/multiStep/paab.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/paab.test.ts
@@ -322,10 +322,10 @@ describe('multiStep environment test', () => {
     expect(researcherProj1Environments.data.filter((env) => env.id === env1.id).length).toEqual(1);
     expect(researcherProj1Environments.data.filter((env) => env.id === env3.id).length).toEqual(0);
 
-    console.log('Verifying Researcher1 CANNOT see Environment1 on single get REQUEST using project3 Request');
+    console.log('Verifying Researcher1 CANNOT see Environment1 on single get REQUEST using project3');
     await expect(
       rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).get()
-    ).toThrow(
+    ).rejects.toThrowError(
       new HttpError(404, { error: `Couldnt find environment ${env1.id} with project ${project3Id}` })
     );
 
@@ -464,12 +464,12 @@ describe('multiStep environment test', () => {
     console.log('Verifying Researcher1 CANNOT stop Environment1 using project3');
     await expect(
       rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).stop()
-    ).toThrow(unauthorizedHttpError);
+    ).rejects.toThrowError(unauthorizedHttpError);
 
     console.log('Verifying Researcher1 CANNOT connect Environment1 using project3');
     await expect(
       rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).connect()
-    ).toThrow(unauthorizedHttpError);
+    ).rejects.toThrowError(unauthorizedHttpError);
     // Connect
     await rs1Session.resources.projects.project(project1Id).environments().environment(env1.id).connect();
     // Stop
@@ -528,12 +528,12 @@ describe('multiStep environment test', () => {
     console.log('Verifying Researcher1 CANNOT start Environment1 using project3');
     await expect(
       rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).start()
-    ).toThrow(unauthorizedHttpError);
+    ).rejects.toThrowError(unauthorizedHttpError);
 
     console.log('Verifying Researcher1 CANNOT terminate Environment1 using project3');
     await expect(
       rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).terminate()
-    ).toThrow(unauthorizedHttpError);
+    ).rejects.toThrowError(unauthorizedHttpError);
 
     await rs1Session.resources.projects.project(project1Id).environments().environment(env1.id).terminate();
 

--- a/solutions/swb-reference/integration-tests/tests/multiStep/paab.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/paab.test.ts
@@ -322,6 +322,13 @@ describe('multiStep environment test', () => {
     expect(researcherProj1Environments.data.filter((env) => env.id === env1.id).length).toEqual(1);
     expect(researcherProj1Environments.data.filter((env) => env.id === env3.id).length).toEqual(0);
 
+    console.log('Verifying Researcher1 CANNOT see Environment1 on single get REQUEST using project3 Request');
+    await expect(
+      rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).get()
+    ).toThrow(
+      new HttpError(404, { error: `Couldnt find environment ${env1.id} with project ${project3Id}` })
+    );
+
     console.log('Verifying Researcher1 CAN ONLY see Environment3 on project3 Request');
     // List Environments for Project
     const { data: researcherProj3Environments }: ListEnvironmentResponse = await rs1Session.resources.projects
@@ -453,6 +460,16 @@ describe('multiStep environment test', () => {
       'COMPLETED',
       ENVIRONMENT_START_MAX_WAITING_SECONDS
     );
+
+    console.log('Verifying Researcher1 CANNOT stop Environment1 using project3');
+    await expect(
+      rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).stop()
+    ).toThrow(unauthorizedHttpError);
+
+    console.log('Verifying Researcher1 CANNOT connect Environment1 using project3');
+    await expect(
+      rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).connect()
+    ).toThrow(unauthorizedHttpError);
     // Connect
     await rs1Session.resources.projects.project(project1Id).environments().environment(env1.id).connect();
     // Stop
@@ -507,6 +524,17 @@ describe('multiStep environment test', () => {
       'STOPPED',
       ENVIRONMENT_STOP_MAX_WAITING_SECONDS
     );
+
+    console.log('Verifying Researcher1 CANNOT start Environment1 using project3');
+    await expect(
+      rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).start()
+    ).toThrow(unauthorizedHttpError);
+
+    console.log('Verifying Researcher1 CANNOT terminate Environment1 using project3');
+    await expect(
+      rs1Session.resources.projects.project(project3Id).environments().environment(env1.id).terminate()
+    ).toThrow(unauthorizedHttpError);
+
     await rs1Session.resources.projects.project(project1Id).environments().environment(env1.id).terminate();
 
     console.log('Verifying ITAdmin can terminate environment2...');


### PR DESCRIPTION
Issue #, if available:
GALI-2437
Description of changes:
-Validate environment is part of a project on get Request
-Add integ test validating project belongs to environment on environment APIs

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.