### PR TITLE
fix: ignore js files from sonar scans

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -22,15 +22,11 @@ sonar.exclusions=\
     # Skipping scans on compiled/build files
     **/node_modules/**, \
     **/*.js, \
-    **/lib/**/*.js, \
-    **/lib/**/*.map, \
-    **/lib/**/*d.ts, \
-    **/lib/**/*.json,git, \
-    **/build/**/*.js, \
-    **/build/**/*.map, \
-    **/build/**/*d.ts, \
+    **/*.map, \
+    **/*.d.ts, \
+    **/*.json,git, \
     **/cdk.out/**, \
-    **/tsconfig-base.json, \
+    **/tsconfig.json, \
 
     # These Python scripts from published AWS repo https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples
     # They run on the SageMaker instance to get its own session info and create a boot config

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,6 +21,7 @@ sonar.exclusions=\
 
     # Skipping scans on compiled/build files
     **/node_modules/**, \
+    **/*.js, \
     **/lib/**/*.js, \
     **/lib/**/*.map, \
     **/lib/**/*d.ts, \
@@ -29,7 +30,7 @@ sonar.exclusions=\
     **/build/**/*.map, \
     **/build/**/*d.ts, \
     **/cdk.out/**, \
-    **/tsconfig.json, \
+    **/tsconfig-base.json, \
 
     # These Python scripts from published AWS repo https://github.com/aws-samples/amazon-sagemaker-notebook-instance-lifecycle-config-samples
     # They run on the SageMaker instance to get its own session info and create a boot config


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Ignore js files in sonar scanning since build/lib exclusion isn't taking effect.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.