### PR TITLE
fix: ignore build folders for sonar scan

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,6 +21,8 @@ sonar.exclusions=\
 
     # Skipping scans on compiled/build files
     **/node_modules/**, \
+    **/build/**, \
+    **/lib/**, \
     **/*.js, \
     **/*.map, \
     **/*.d.ts, \


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Ignore build and lib folders for sonar scan.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.