### PR TITLE
chore(zod): add zod model for regex

### DIFF
--- a/common/changes/@aws/workbench-core-base/janeyu-zodModel_2023-04-19-21-57.json
+++ b/common/changes/@aws/workbench-core-base/janeyu-zodModel_2023-04-19-21-57.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "add Zod model regex",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/workbench-core/base/src/utilities/textUtil.ts
+++ b/workbench-core/base/src/utilities/textUtil.ts
@@ -27,6 +27,12 @@ function uuidWithLowercasePrefixRegExp(prefix: string): RegExp {
   return new RegExp(`${prefix.toLowerCase()}-${uuidRegExpAsString}$`);
 }
 
+function nonHtmlRegExp(): RegExp {
+  const htmlRegExpAsString = /<[^>]*>/gm;
+  // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
+  return new RegExp(`^(?!.*${htmlRegExpAsString.source}).*$`);
+}
+
 const validRolesRegExpAsString: string = '(ProjectAdmin|Researcher)';
 
 const validSshKeyUuidRegExpAsString: string = '[0-9a-f]{64}';
@@ -35,6 +41,7 @@ export {
   uuidWithLowercasePrefix,
   uuidRegExp,
   uuidWithLowercasePrefixRegExp,
+  nonHtmlRegExp,
   uuidRegExpAsString,
   productIdRegExpString,
   provisionArtifactIdRegExpString,

--- a/workbench-core/base/src/utilities/textUtil.ts
+++ b/workbench-core/base/src/utilities/textUtil.ts
@@ -28,9 +28,9 @@ function uuidWithLowercasePrefixRegExp(prefix: string): RegExp {
 }
 
 function nonHtmlRegExp(): RegExp {
-  const htmlRegExpAsString = /<[^>]*>/gm;
+  const nonHtmlRegExpAsString = '^([^<>{}]*)$';
   // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
-  return new RegExp(`^(?!.*${htmlRegExpAsString.source}).*$`);
+  return new RegExp(nonHtmlRegExpAsString);
 }
 
 const validRolesRegExpAsString: string = '(ProjectAdmin|Researcher)';

--- a/workbench-core/base/src/utilities/textUtil.ts
+++ b/workbench-core/base/src/utilities/textUtil.ts
@@ -11,13 +11,15 @@ function uuidWithLowercasePrefix(prefix: string): string {
 }
 const uuidRegExpAsString: string = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
 
+const nonHTMLValidChar: string = 'must not contain any of <>{}';
 const nonHtmlRegExpAsString: string = '^([^<>{}]*)$';
 
-// swbName must contain only letters, numbers, hyphens, underscores, and periods
+const swbNameValidChar: string = 'must contain only letters, numbers, hyphens, underscores, and periods';
 const swbNameRegExpAsString: string = '^[A-Za-z0-9-_.]+$';
 const swbNameMaxLength: number = 112;
 
-// swbDescription must contain only letters, numbers, hyphens, underscores, periods, and spaces
+const swbDescriptionValidChar: string =
+  'must contain only letters, numbers, hyphens, underscores, periods, and spaces';
 const swbDescriptionRegExpAsString: string = '^[A-Za-z0-9-_. ]+$';
 const swbDescriptionMaxLength: number = 400;
 
@@ -60,9 +62,12 @@ export {
   uuidWithLowercasePrefix,
   uuidRegExp,
   uuidWithLowercasePrefixRegExp,
+  nonHTMLValidChar,
   nonHtmlRegExp,
+  swbNameValidChar,
   swbNameRegExp,
   swbNameMaxLength,
+  swbDescriptionValidChar,
   swbDescriptionRegExp,
   swbDescriptionMaxLength,
   uuidRegExpAsString,

--- a/workbench-core/base/src/utilities/textUtil.ts
+++ b/workbench-core/base/src/utilities/textUtil.ts
@@ -11,6 +11,16 @@ function uuidWithLowercasePrefix(prefix: string): string {
 }
 const uuidRegExpAsString: string = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
 
+const nonHtmlRegExpAsString: string = '^([^<>{}]*)$';
+
+// swbName must contain only letters, numbers, hyphens, underscores, and periods
+const swbNameRegExpAsString: string = '^[A-Za-z0-9-_.]+$';
+const swbNameMaxLength: number = 112;
+
+// swbDescription must contain only letters, numbers, hyphens, underscores, periods, and spaces
+const swbDescriptionRegExpAsString: string = '^[A-Za-z0-9-_. ]+$';
+const swbDescriptionMaxLength: number = 400;
+
 const groupIDRegExpAsString: string = '\\S{1,128}';
 
 const productIdRegExpString: string = 'prod-[0-9a-zA-Z]{13}';
@@ -28,9 +38,18 @@ function uuidWithLowercasePrefixRegExp(prefix: string): RegExp {
 }
 
 function nonHtmlRegExp(): RegExp {
-  const nonHtmlRegExpAsString = '^([^<>{}]*)$';
   // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
   return new RegExp(nonHtmlRegExpAsString);
+}
+
+function swbNameRegExp(): RegExp {
+  // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
+  return new RegExp(swbNameRegExpAsString);
+}
+
+function swbDescriptionRegExp(): RegExp {
+  // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
+  return new RegExp(swbDescriptionRegExpAsString);
 }
 
 const validRolesRegExpAsString: string = '(ProjectAdmin|Researcher)';
@@ -42,6 +61,10 @@ export {
   uuidRegExp,
   uuidWithLowercasePrefixRegExp,
   nonHtmlRegExp,
+  swbNameRegExp,
+  swbNameMaxLength,
+  swbDescriptionRegExp,
+  swbDescriptionMaxLength,
   uuidRegExpAsString,
   productIdRegExpString,
   provisionArtifactIdRegExpString,

--- a/workbench-core/base/src/utilities/validatorHelper.test.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.test.ts
@@ -4,7 +4,13 @@
  */
 
 import JSONValue from '../types/json';
-import { swbNameMaxLength, swbDescriptionMaxLength } from './textUtil';
+import {
+  nonHTMLValidChar,
+  swbNameMaxLength,
+  swbNameValidChar,
+  swbDescriptionMaxLength,
+  swbDescriptionValidChar
+} from './textUtil';
 import { getPaginationParser, validateAndParse, z } from './validatorHelper';
 
 describe('getPaginationProperties', () => {
@@ -228,9 +234,7 @@ describe('tests for zod.nonHTML', () => {
       { id: "randomString<tag\nkey='value'/> randomString" }
     ];
     test.each(invalidObjects)('returns required message', (invalidObject) => {
-      expect(() => validateAndParse<NonHTMLType>(zodParser, invalidObject)).toThrowError(
-        'id: Input contains HTML'
-      );
+      expect(() => validateAndParse<NonHTMLType>(zodParser, invalidObject)).toThrowError(nonHTMLValidChar);
     });
   });
 });
@@ -270,7 +274,7 @@ describe('tests for zod.swbName', () => {
       ];
       test.each(invalidObjects)('returns required message', (invalidObject) => {
         expect(() => validateAndParse<SwbNameType>(zodParser, invalidObject)).toThrowError(
-          'invalid input characters'
+          `${swbNameValidChar}`
         );
       });
     });
@@ -311,7 +315,7 @@ describe('tests for zod.swbDescription', () => {
       ];
       test.each(invalidObjects)('returns required message', (invalidObject) => {
         expect(() => validateAndParse<SwbDescriptionType>(zodParser, invalidObject)).toThrowError(
-          'invalid input characters'
+          `${swbDescriptionValidChar}`
         );
       });
     });

--- a/workbench-core/base/src/utilities/validatorHelper.test.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.test.ts
@@ -197,7 +197,7 @@ describe('zod.nonHTML', () => {
   type NonHTMLType = z.infer<typeof zodParser>;
 
   describe('when input does not contains', () => {
-    const validObjects = [{ id: 'non HTML' }, { id: '<' }, { id: '>' }];
+    const validObjects = [{ id: 'non HTML' }];
     test.each(validObjects)('returns valid Id', (validObject) => {
       expect(validateAndParse<NonHTMLType>(zodParser, validObject)).toEqual(validObject);
     });
@@ -205,6 +205,11 @@ describe('zod.nonHTML', () => {
 
   describe('when input contains HTML', () => {
     const invalidObjects = [
+      // String with any of <>{}
+      { id: '<' },
+      { id: '>' },
+      { id: '{' },
+      { id: '}' },
       // String is HTML with empty quote
       { id: '<>' },
       // String is HTML with double quote

--- a/workbench-core/base/src/utilities/validatorHelper.test.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.test.ts
@@ -213,9 +213,13 @@ describe('zod.nonHTML', () => {
       // String is Single quote HTML
       { id: "<tag key='value'/>" },
       // String contains HTML
+      { id: "randomString<tag key='value'></tag> randomString" },
+      { id: "randomString<tag key='value'>content</tag> randomString" },
       { id: "randomString<tag key='value'/> randomString" },
+      // String contains multiple HTML
+      { id: "randomString<tag key='value'/> randomString <tag key='value'/> randomString" },
       //multi-line with HTML
-      { id: 'randomString<tag ' + "key='value'/> randomString" }
+      { id: "randomString<tag\nkey='value'/> randomString" }
     ];
     test.each(invalidObjects)('returns required message', (invalidObject) => {
       expect(() => validateAndParse<NonHTMLType>(zodParser, invalidObject)).toThrowError(

--- a/workbench-core/base/src/utilities/validatorHelper.test.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.test.ts
@@ -4,6 +4,7 @@
  */
 
 import JSONValue from '../types/json';
+import { swbNameMaxLength, swbDescriptionMaxLength } from './textUtil';
 import { getPaginationParser, validateAndParse, z } from './validatorHelper';
 
 describe('getPaginationProperties', () => {
@@ -190,13 +191,13 @@ describe('zod.required', () => {
   });
 });
 
-describe('zod.nonHTML', () => {
+describe('tests for zod.nonHTML', () => {
   const zodParser = z.object({
     id: z.string().nonHTML()
   });
   type NonHTMLType = z.infer<typeof zodParser>;
 
-  describe('when input does not contains', () => {
+  describe('when input does not contains HTML', () => {
     const validObjects = [{ id: 'non HTML' }];
     test.each(validObjects)('returns valid Id', (validObject) => {
       expect(validateAndParse<NonHTMLType>(zodParser, validObject)).toEqual(validObject);
@@ -230,6 +231,89 @@ describe('zod.nonHTML', () => {
       expect(() => validateAndParse<NonHTMLType>(zodParser, invalidObject)).toThrowError(
         'id: Input contains HTML'
       );
+    });
+  });
+});
+
+describe('tests for zod.swbName', () => {
+  const zodParser = z.object({
+    id: z.string().swbName()
+  });
+  type SwbNameType = z.infer<typeof zodParser>;
+
+  describe('when input is valid', () => {
+    const validObjects = [{ id: 'ABCabc123-_.' }];
+    test.each(validObjects)('returns valid Id', (validObject) => {
+      expect(validateAndParse<SwbNameType>(zodParser, validObject)).toEqual(validObject);
+    });
+  });
+
+  describe('when input is not valid', () => {
+    describe('when length exceed maximum', () => {
+      const invalidObjects = [
+        // String exceeds max length
+        { id: 'A'.repeat(swbNameMaxLength + 1) }
+      ];
+      test.each(invalidObjects)('returns required message', (invalidObject) => {
+        expect(() => validateAndParse<SwbNameType>(zodParser, invalidObject)).toThrowError(
+          `id: Input must be less than ${swbNameMaxLength} characters`
+        );
+      });
+    });
+
+    describe('when contains invalid char', () => {
+      const invalidObjects = [
+        // String contains invalid character
+        { id: '<' },
+        { id: ' ' },
+        { id: 'aaa&123' }
+      ];
+      test.each(invalidObjects)('returns required message', (invalidObject) => {
+        expect(() => validateAndParse<SwbNameType>(zodParser, invalidObject)).toThrowError(
+          'invalid input characters'
+        );
+      });
+    });
+  });
+});
+
+describe('tests for zod.swbDescription', () => {
+  const zodParser = z.object({
+    id: z.string().swbDescription()
+  });
+  type SwbDescriptionType = z.infer<typeof zodParser>;
+
+  describe('when input is valid', () => {
+    const validObjects = [{ id: 'ABCabc123-_. ' }];
+    test.each(validObjects)('returns valid Id', (validObject) => {
+      expect(validateAndParse<SwbDescriptionType>(zodParser, validObject)).toEqual(validObject);
+    });
+  });
+
+  describe('when input is not valid', () => {
+    describe('when length exceed maximum', () => {
+      const invalidObjects = [
+        // String exceeds max length
+        { id: 'A'.repeat(swbDescriptionMaxLength + 1) }
+      ];
+      test.each(invalidObjects)('returns required message', (invalidObject) => {
+        expect(() => validateAndParse<SwbDescriptionType>(zodParser, invalidObject)).toThrowError(
+          `id: Input must be less than ${swbDescriptionMaxLength} characters`
+        );
+      });
+    });
+
+    describe('when contains invalid char', () => {
+      const invalidObjects = [
+        // String contains invalid character
+        { id: '<' },
+        { id: 'aaa&123' }
+      ];
+      test.each(invalidObjects)('returns required message', (invalidObject) => {
+        expect(() => validateAndParse<SwbDescriptionType>(zodParser, invalidObject)).toThrowError(
+          'invalid input characters'
+        );
+      });
     });
   });
 });

--- a/workbench-core/base/src/utilities/validatorHelper.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.ts
@@ -6,9 +6,12 @@
 import * as Boom from '@hapi/boom';
 import { z, ZodString, ZodTypeAny } from 'zod';
 import {
+  nonHTMLValidChar,
   nonHtmlRegExp,
+  swbNameValidChar,
   swbNameRegExp,
   swbDescriptionRegExp,
+  swbDescriptionValidChar,
   swbDescriptionMaxLength,
   swbNameMaxLength,
   uuidWithLowercasePrefixRegExp
@@ -38,19 +41,19 @@ z.ZodString.prototype.swbId = function (prefix: string): ZodString {
 };
 
 z.ZodString.prototype.nonHTML = function (): ZodString {
-  return this.regex(nonHtmlRegExp(), { message: 'Input contains HTML' });
+  return this.regex(nonHtmlRegExp(), { message: nonHTMLValidChar });
 };
 
 z.ZodString.prototype.swbName = function (): ZodString {
   return this.max(swbNameMaxLength, {
     message: `Input must be less than ${swbNameMaxLength} characters`
-  }).regex(swbNameRegExp(), { message: 'invalid input characters' });
+  }).regex(swbNameRegExp(), { message: swbNameValidChar });
 };
 
 z.ZodString.prototype.swbDescription = function (): ZodString {
   return this.max(swbDescriptionMaxLength, {
     message: `Input must be less than ${swbDescriptionMaxLength} characters`
-  }).regex(swbDescriptionRegExp(), { message: 'invalid input characters' });
+  }).regex(swbDescriptionRegExp(), { message: swbDescriptionValidChar });
 };
 
 function getPaginationParser(minPageSize: number = 1, maxPageSize: number = 100): ZodPagination {

--- a/workbench-core/base/src/utilities/validatorHelper.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.ts
@@ -5,7 +5,7 @@
 
 import * as Boom from '@hapi/boom';
 import { z, ZodString, ZodTypeAny } from 'zod';
-import { uuidWithLowercasePrefixRegExp } from './textUtil';
+import { nonHtmlRegExp, uuidWithLowercasePrefixRegExp } from './textUtil';
 
 interface ZodPagination {
   pageSize: z.ZodOptional<z.ZodEffects<z.ZodString, number, string>>;
@@ -16,6 +16,7 @@ declare module 'zod' {
   export interface ZodString {
     required: () => ZodString;
     swbId: (prefix: string) => ZodString;
+    nonHTML: () => ZodString;
   }
 }
 
@@ -25,6 +26,10 @@ z.ZodString.prototype.required = function (): ZodString {
 
 z.ZodString.prototype.swbId = function (prefix: string): ZodString {
   return this.regex(uuidWithLowercasePrefixRegExp(prefix), { message: 'Invalid ID' });
+};
+
+z.ZodString.prototype.nonHTML = function (): ZodString {
+  return this.regex(nonHtmlRegExp(), { message: 'Input contains HTML' });
 };
 
 function getPaginationParser(minPageSize: number = 1, maxPageSize: number = 100): ZodPagination {

--- a/workbench-core/base/src/utilities/validatorHelper.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.ts
@@ -5,7 +5,14 @@
 
 import * as Boom from '@hapi/boom';
 import { z, ZodString, ZodTypeAny } from 'zod';
-import { nonHtmlRegExp, uuidWithLowercasePrefixRegExp } from './textUtil';
+import {
+  nonHtmlRegExp,
+  swbNameRegExp,
+  swbDescriptionRegExp,
+  swbDescriptionMaxLength,
+  swbNameMaxLength,
+  uuidWithLowercasePrefixRegExp
+} from './textUtil';
 
 interface ZodPagination {
   pageSize: z.ZodOptional<z.ZodEffects<z.ZodString, number, string>>;
@@ -17,6 +24,8 @@ declare module 'zod' {
     required: () => ZodString;
     swbId: (prefix: string) => ZodString;
     nonHTML: () => ZodString;
+    swbName: () => ZodString;
+    swbDescription: () => ZodString;
   }
 }
 
@@ -30,6 +39,18 @@ z.ZodString.prototype.swbId = function (prefix: string): ZodString {
 
 z.ZodString.prototype.nonHTML = function (): ZodString {
   return this.regex(nonHtmlRegExp(), { message: 'Input contains HTML' });
+};
+
+z.ZodString.prototype.swbName = function (): ZodString {
+  return this.max(swbNameMaxLength, {
+    message: `Input must be less than ${swbNameMaxLength} characters`
+  }).regex(swbNameRegExp(), { message: 'invalid input characters' });
+};
+
+z.ZodString.prototype.swbDescription = function (): ZodString {
+  return this.max(swbDescriptionMaxLength, {
+    message: `Input must be less than ${swbDescriptionMaxLength} characters`
+  }).regex(swbDescriptionRegExp(), { message: 'invalid input characters' });
 };
 
 function getPaginationParser(minPageSize: number = 1, maxPageSize: number = 100): ZodPagination {


### PR DESCRIPTION
Issue #, if available: GALI-2327

Description of changes:
Create Zod models we can reuse for regex strings. New methods
* nonHTML 
* swbName with max length and valid char
* swbDescription with max length and valid char

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.