### PR TITLE
fix(swb datsets): shorten TTL for 2 min for upload to dataset

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -98,7 +98,8 @@
       "jszip": ">=3.8.0",
       "http-cache-semantics": ">=4.1.1",
       "cacheable-request": ">=10.2.7",
-      "xml2js": ">=0.5.0"
+      "xml2js": ">=0.5.0",
+      "yaml":  ">=2.2.2"
     },
 
     /**

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   http-cache-semantics: '>=4.1.1'
   cacheable-request: '>=10.2.7'
   xml2js: '>=0.5.0'
+  yaml: '>=2.2.2'
 
 importers:
 
@@ -7539,7 +7540,7 @@ packages:
       punycode: 2.3.0
       semver: 7.3.8
       table: 6.8.1
-      yaml: 1.10.2
+      yaml: 2.2.2
     bundledDependencies:
       - '@balena/dockerignore'
       - case
@@ -7735,7 +7736,7 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001480
+      caniuse-lite: 1.0.30001481
       electron-to-chromium: 1.4.227
       node-releases: 2.0.6
       update-browserslist-db: 1.0.5_browserslist@4.21.3
@@ -7852,8 +7853,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /caniuse-lite/1.0.30001480:
-    resolution: {integrity: sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==}
+  /caniuse-lite/1.0.30001481:
+    resolution: {integrity: sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==}
 
   /case/1.6.3:
     resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
@@ -8172,7 +8173,7 @@ packages:
       import-fresh: 3.3.0
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.2
+      yaml: 2.2.2
     dev: true
 
   /create-require/1.1.1:
@@ -11816,7 +11817,7 @@ packages:
         optional: true
     dependencies:
       '@next/env': 12.1.6
-      caniuse-lite: 1.0.30001480
+      caniuse-lite: 1.0.30001481
       postcss: 8.4.5
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -14463,9 +14464,9 @@ packages:
       js-yaml: 4.1.0
     dev: true
 
-  /yaml/1.10.2:
-    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
-    engines: {node: '>= 6'}
+  /yaml/2.2.2:
+    resolution: {integrity: sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==}
+    engines: {node: '>= 14'}
 
   /yargs-parser/13.1.2:
     resolution: {integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "f3bd9f8f3a6335728fe088d07c35acc45d8ccf59",
+  "pnpmShrinkwrapHash": "d3fd47a4c3e16cd8b02c1ea9b318187f34be35bf",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/solutions/swb-reference/src/services/dataSetService.ts
+++ b/solutions/swb-reference/src/services/dataSetService.ts
@@ -36,8 +36,7 @@ import { SwbAuthZSubject } from '../constants';
 import { getProjectAdminRole, getResearcherRole } from '../utils/roleUtils';
 import { Associable, DatabaseServicePlugin } from './databaseService';
 
-const timeToLiveSeconds: number = 60 * 15; // 15 min
-
+const timeToLiveSeconds: number = 60 * 2; // 2 min
 export class DataSetService implements DataSetPlugin {
   public readonly storagePlugin: DataSetStoragePlugin;
   private _dataSetsAuthService: DataSetsAuthorizationPlugin;


### PR DESCRIPTION
Issue #, if available: GALI-2409

Description of changes:
2 minutes TTL for S3 presigned URL for upload files to dataset based on the fact that we need our customers to manually interact with the URL and human interaction requires a reasonable time limit that is feasible to then use this URL. If we automate the interaction with the presigned URL in the future, we can shorten it even more.

I have manually tested that this time limit is reasonable and that it is imposed by this code change.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.