### PR TITLE
feat(swb-ref): adding auth APIs to postman/openapi collections

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -154,6 +154,7 @@ importers:
       lodash: ^4.17.21
       npm-package-json-lint: ^6.3.0
       npm-package-json-lint-config-default: ^5.0.0
+      pkce-challenge: ^3.0.0
       qs: ^6.11.0
       sort-package-json: ^1.57.0
       ts-node: ^10.4.0
@@ -183,6 +184,7 @@ importers:
       express: 4.18.1
       js-yaml: 4.1.0
       lodash: 4.17.21
+      pkce-challenge: 3.0.0
       qs: 6.11.0
       uuid: 8.3.2
     devDependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,5 +1,5 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "d3fd47a4c3e16cd8b02c1ea9b318187f34be35bf",
+  "pnpmShrinkwrapHash": "4a39280a5ff833feae33c70b153425c990b4f03e",
   "preferredVersionsHash": "bf21a9e8fbc5a3846fb05b4fa0859e0917b2202f"
 }

--- a/solutions/swb-reference/SWBv2.openapi.json
+++ b/solutions/swb-reference/SWBv2.openapi.json
@@ -2922,6 +2922,240 @@
           }
         }
       ]
+    },
+    "/login": {
+      "get": {
+        "tags": ["auth"],
+        "summary": "Login",
+        "description": "Login",
+        "operationId": "login",
+        "parameters": [
+          {
+            "name": "stateVerifier",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "example": ""
+            }
+          },
+          {
+            "name": "codeChallenge",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "example": ""
+            }
+          },
+          {
+            "name": "Cookie",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}}"
+            }
+          },
+          {
+            "name": "csrf-token",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{CSRF_TOKEN}}"
+            }
+          },
+          {
+            "name": "origin",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{API_URL}}"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/token": {
+      "post": {
+        "tags": ["auth"],
+        "summary": "Exchange Auth Code for Token",
+        "description": "Exchange Auth Code for Token",
+        "operationId": "exchangeAuthCodeForToken",
+        "parameters": [
+          {
+            "name": "Cookie",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}}"
+            }
+          },
+          {
+            "name": "csrf-token",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{CSRF_TOKEN}}"
+            }
+          },
+          {
+            "name": "origin",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{API_URL}}"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string",
+                    "example": "authCode"
+                  },
+                  "codeVerifier": {
+                    "type": "string",
+                    "example": "codeChallenge"
+                  }
+                }
+              },
+              "example": {
+                "code": "authCode",
+                "codeVerifier": "codeChallenge"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/logout": {
+      "post": {
+        "tags": ["auth"],
+        "summary": "Logout",
+        "description": "Logout",
+        "operationId": "logout",
+        "parameters": [
+          {
+            "name": "Cookie",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}};refresh_token={{REFRESH_TOKEN}}"
+            }
+          },
+          {
+            "name": "csrf-token",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{CSRF_TOKEN}}"
+            }
+          },
+          {
+            "name": "origin",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{API_URL}}"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/refresh": {
+      "get": {
+        "tags": ["auth"],
+        "summary": "Refresh",
+        "description": "Refresh",
+        "operationId": "refresh",
+        "parameters": [
+          {
+            "name": "Cookie",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}};refresh_token={{REFRESH_TOKEN}}"
+            }
+          },
+          {
+            "name": "csrf-token",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{CSRF_TOKEN}}"
+            }
+          },
+          {
+            "name": "origin",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{API_URL}}"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/loggedIn": {
+      "get": {
+        "tags": ["auth"],
+        "summary": "IsLoggedIn",
+        "description": "IsLoggedIn",
+        "operationId": "isloggedin",
+        "parameters": [
+          {
+            "name": "Cookie",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}};refresh_token={{REFRESH_TOKEN}}"
+            }
+          },
+          {
+            "name": "csrf-token",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{CSRF_TOKEN}}"
+            }
+          },
+          {
+            "name": "origin",
+            "in": "header",
+            "schema": {
+              "type": "string",
+              "example": "{{API_URL}}"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        }
+      }
     }
   },
   "tags": [
@@ -2951,6 +3185,9 @@
     },
     {
       "name": "sshKeys"
+    },
+    {
+      "name": "auth"
     }
   ]
 }

--- a/solutions/swb-reference/SWBv2.postman_collection.json
+++ b/solutions/swb-reference/SWBv2.postman_collection.json
@@ -2257,6 +2257,179 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "auth",
+      "item": [
+        {
+          "name": "Login",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Cookie",
+                "value": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}}",
+                "type": "text",
+                "disabled": true
+              },
+              {
+                "key": "csrf-token",
+                "value": "{{CSRF_TOKEN}}",
+                "type": "text",
+                "disabled": true
+              },
+              {
+                "key": "origin",
+                "value": "{{API_URL}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{API_URL}}/login",
+              "host": ["{{API_URL}}"],
+              "path": ["login"],
+              "query": [
+                {
+                  "key": "stateVerifier",
+                  "value": "",
+                  "disabled": false
+                },
+                {
+                  "key": "codeChallenge",
+                  "value": "",
+                  "disabled": false
+                }
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Exchange Auth Code for Token",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Cookie",
+                "value": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}}",
+                "type": "text"
+              },
+              {
+                "key": "csrf-token",
+                "value": "{{CSRF_TOKEN}}",
+                "type": "text"
+              },
+              {
+                "key": "origin",
+                "value": "{{API_URL}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"code\": \"authCode\",\n    \"codeVerifier\": \"codeChallenge\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{API_URL}}/token",
+              "host": ["{{API_URL}}"],
+              "path": ["token"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Logout",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Cookie",
+                "value": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}};refresh_token={{REFRESH_TOKEN}}",
+                "type": "text"
+              },
+              {
+                "key": "csrf-token",
+                "value": "{{CSRF_TOKEN}}",
+                "type": "text"
+              },
+              {
+                "key": "origin",
+                "value": "{{API_URL}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{API_URL}}/logout",
+              "host": ["{{API_URL}}"],
+              "path": ["logout"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Refresh",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Cookie",
+                "value": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}};refresh_token={{REFRESH_TOKEN}}",
+                "type": "text"
+              },
+              {
+                "key": "csrf-token",
+                "value": "{{CSRF_TOKEN}}",
+                "type": "text"
+              },
+              {
+                "key": "origin",
+                "value": "{{API_URL}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{API_URL}}/refresh",
+              "host": ["{{API_URL}}"],
+              "path": ["refresh"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "IsLoggedIn",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Cookie",
+                "value": "access_token={{ACCESS_TOKEN}};_csrf={{CSRF_COOKIE}};refresh_token={{REFRESH_TOKEN}}",
+                "type": "text"
+              },
+              {
+                "key": "csrf-token",
+                "value": "{{CSRF_TOKEN}}",
+                "type": "text"
+              },
+              {
+                "key": "origin",
+                "value": "{{API_URL}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{API_URL}}/loggedIn",
+              "host": ["{{API_URL}}"],
+              "path": ["loggedIn"]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/solutions/swb-reference/package.json
+++ b/solutions/swb-reference/package.json
@@ -60,7 +60,6 @@
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "pkce-challenge": "^3.0.0",
-    "postman2openapi": "~1.0.0",
     "qs": "^6.11.0",
     "uuid": "^8.3.2"
   },

--- a/solutions/swb-reference/package.json
+++ b/solutions/swb-reference/package.json
@@ -25,6 +25,7 @@
     "cognito-tokens": "node scripts/generateCognitoTokens.js ${EMAIL} ${PASSWORD}",
     "compile": "node scripts/buildLambda.js",
     "depcheck": "depcheck",
+    "get-code-challenge": "node scripts/generateCodeChallenge.js",
     "integration-tests": "rushx build && jest lib/integration-tests -i",
     "jest": "jest",
     "license-checker": "license-checker --onlyAllow 'MIT; Apache-2.0; ISC; BSD'",
@@ -58,6 +59,8 @@
     "express": "^4.17.3",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
+    "pkce-challenge": "^3.0.0",
+    "postman2openapi": "~1.0.0",
     "qs": "^6.11.0",
     "uuid": "^8.3.2"
   },

--- a/solutions/swb-reference/scripts/generateCodeChallenge.js
+++ b/solutions/swb-reference/scripts/generateCodeChallenge.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const pkceChallenge = require('pkce-challenge').default;
+const { v4: uuid } = require('uuid');
+
+const challenge = pkceChallenge(128);
+
+console.log(`CodeChallenge: ${challenge.code_challenge}`);
+console.log(`CodeVerifier: ${challenge.code_verifier}`);
+console.log(`StateVerifier: ${uuid()}`);


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Add auth APIs to postman and openapi collections
* Add script to generate code challenge and verifiers used for login/exchange auth code

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.