### PR TITLE
fix(AppSec): s3 accesslog bucket only accept HTTPS

### DIFF
--- a/solutions/swb-reference/src/SWBStack.ts
+++ b/solutions/swb-reference/src/SWBStack.ts
@@ -716,6 +716,21 @@ export class SWBStack extends Stack {
       })
     );
 
+    s3Bucket.addToResourcePolicy(
+      new PolicyStatement({
+        sid: 'Deny requests that do not use TLS/HTTPS',
+        effect: Effect.DENY,
+        principals: [new AnyPrincipal()],
+        actions: ['s3:*'],
+        resources: [s3Bucket.bucketArn, s3Bucket.arnForObjects('*')],
+        conditions: {
+          Bool: {
+            'aws:SecureTransport': 'false'
+          }
+        }
+      })
+    );
+
     new CfnOutput(this, bucketNameOutput, {
       value: s3Bucket.bucketName,
       exportName: bucketNameOutput


### PR DESCRIPTION
Issue #, if available:V869865466

Description of changes:
Update access log bucket config to be HTTPS only

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.