### PR TITLE
chore(env list, et routes): add input length and format validation

### DIFF
--- a/common/changes/@aws/swb-app/farandac-et-input-validation_2023-04-26-05-30.json
+++ b/common/changes/@aws/swb-app/farandac-et-input-validation_2023-04-26-05-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "Update route status response for environment and environment types",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/common/changes/@aws/workbench-core-base/farandac-et-input-validation_2023-04-26-05-30.json
+++ b/common/changes/@aws/workbench-core-base/farandac-et-input-validation_2023-04-26-05-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-base",
+      "comment": "add lenght restriction functions",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-base"
+}

--- a/common/changes/@aws/workbench-core-environments/farandac-et-input-validation_2023-04-26-05-30.json
+++ b/common/changes/@aws/workbench-core-environments/farandac-et-input-validation_2023-04-26-05-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-environments",
+      "comment": "restrict ET model inputs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-environments"
+}

--- a/solutions/swb-app/src/environmentRoutes.ts
+++ b/solutions/swb-app/src/environmentRoutes.ts
@@ -19,7 +19,7 @@ export function setUpEnvRoutes(router: Router, environmentService: EnvironmentPl
     wrapAsync(async (req: Request, res: Response) => {
       const request = validateAndParse<ListEnvironmentsRequest>(ListEnvironmentsRequestParser, req.query);
       const response = await environmentService.listEnvironments(request);
-      res.send(response);
+      res.status(200).send(response);
     })
   );
 }

--- a/solutions/swb-app/src/environmentTypeRoutes.ts
+++ b/solutions/swb-app/src/environmentTypeRoutes.ts
@@ -8,7 +8,9 @@ import {
   UpdateEnvironmentTypeRequest,
   UpdateEnvironmentTypeRequestParser,
   ListEnvironmentTypesRequest,
-  ListEnvironmentTypesRequestParser
+  ListEnvironmentTypesRequestParser,
+  GetEnvironmentTypeRequest,
+  GetEnvironmentTypeRequestParser
 } from '@aws/workbench-core-environments';
 import { Request, Response, Router } from 'express';
 import { wrapAsync } from './errorHandlers';
@@ -19,8 +21,11 @@ export function setUpEnvTypeRoutes(router: Router, environmentTypeService: Envir
   router.get(
     '/environmentTypes/:id',
     wrapAsync(async (req: Request, res: Response) => {
-      const envType = await environmentTypeService.getEnvironmentType(req.params.id);
-      res.send(envType);
+      const validatedRequest = validateAndParse<GetEnvironmentTypeRequest>(GetEnvironmentTypeRequestParser, {
+        envTypeId: req.params.id
+      });
+      const envType = await environmentTypeService.getEnvironmentType(validatedRequest.envTypeId);
+      res.status(200).send(envType);
     })
   );
 
@@ -33,7 +38,7 @@ export function setUpEnvTypeRoutes(router: Router, environmentTypeService: Envir
         req.query
       );
       const envTypes = await environmentTypeService.listEnvironmentTypes(request);
-      res.send(envTypes);
+      res.status(200).send(envTypes);
     })
   );
 

--- a/solutions/swb-app/src/projectEnvTypeConfigRoutes.ts
+++ b/solutions/swb-app/src/projectEnvTypeConfigRoutes.ts
@@ -62,7 +62,7 @@ export function setUpProjectEnvTypeConfigRoutes(
           `There was a problem associating project ${req.body.projectId} with etc ${req.params.environmentTypeConfigId}`
         );
       }
-      res.status(201).send();
+      res.status(204).send();
     })
   );
 
@@ -105,7 +105,7 @@ export function setUpProjectEnvTypeConfigRoutes(
       );
       try {
         const relationships = await projectEnvTypeConfigService.listProjectEnvTypeConfigs(request);
-        res.status(201).send(relationships);
+        res.status(200).send(relationships);
       } catch (e) {
         if (Boom.isBoom(e)) {
           throw e;
@@ -127,7 +127,7 @@ export function setUpProjectEnvTypeConfigRoutes(
         envTypeConfigId: req.params.envTypeConfigId
       });
       const relationship = await projectEnvTypeConfigService.getEnvTypeConfig(request);
-      res.status(201).send(relationship);
+      res.status(200).send(relationship);
     })
   );
 
@@ -139,7 +139,7 @@ export function setUpProjectEnvTypeConfigRoutes(
         { envTypeId: req.params.envTypeId, envTypeConfigId: req.params.envTypeConfigId, ...req.query }
       );
       const relationships = await projectEnvTypeConfigService.listEnvTypeConfigProjects(request);
-      res.status(201).send(relationships);
+      res.status(200).send(relationships);
     })
   );
 }

--- a/solutions/swb-reference/integration-tests/support/utils/utilities.ts
+++ b/solutions/swb-reference/integration-tests/support/utils/utilities.ts
@@ -77,4 +77,12 @@ function generateInvalidIds(prefix: string): string[] {
   ];
 }
 
-export { sleep, checkHttpError, poll, getFakeEnvId, generateInvalidIds };
+function generateRandomAlphaNumericString(length: number): string {
+  const validChars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += validChars.charAt(Math.floor(Math.random() * validChars.length));
+  }
+  return result;
+}
+export { sleep, checkHttpError, poll, getFakeEnvId, generateInvalidIds, generateRandomAlphaNumericString };

--- a/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/get.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/get.test.ts
@@ -1,0 +1,62 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+import ClientSession from '../../../support/clientSession';
+import Setup from '../../../support/setup';
+import HttpError from '../../../support/utils/HttpError';
+import { checkHttpError } from '../../../support/utils/utilities';
+
+describe('get environment type', () => {
+  const setup: Setup = Setup.getSetup();
+  let adminSession: ClientSession;
+  const invalidIds = [
+    'et1-prod-1234567890123,pa-1234567890123', //invalid prefix
+    'et-prod1-1234567890123,pa-1234567890123', //invalid product prefix
+    'et-prod-12345678901234,pa-1234567890123', //invalid product length
+    'et-prod-123456789012$,pa-1234567890123', //invalid product character
+    'et-prod-1234567890123,pa1-1234567890123', //invalid provisioning artifact prefix
+    'et-prod-1234567890123,pa-1234567890123423', //invalid provisioning artifact length
+    'et-prod-1234567890123,pa-123456789012$' //invalid provisioning artifact character
+  ];
+  const testEnvTypeId = 'et-prod-0123456789012,pa-0123456789012';
+  beforeEach(() => {
+    expect.hasAssertions();
+  });
+
+  beforeAll(async () => {
+    adminSession = await setup.getDefaultAdminSession();
+  });
+
+  afterAll(async () => {
+    await setup.cleanup();
+  });
+
+  test.each(invalidIds)('fails when trying to get invalid format id', async (invalidId) => {
+    try {
+      await adminSession.resources.environmentTypes.environmentType(invalidId).get();
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          error: 'Bad Request',
+          message: 'envTypeId: Invalid ID'
+        })
+      );
+    }
+  });
+
+  test('fails when trying to get non existing environment Type', async () => {
+    try {
+      await adminSession.resources.environmentTypes.environmentType(testEnvTypeId).get();
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(404, {
+          error: 'Not Found',
+          message: `Could not find environment type ${testEnvTypeId}`
+        })
+      );
+    }
+  });
+});

--- a/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/list.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/list.test.ts
@@ -2,10 +2,11 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
+import { lengthValidationMessage, urlFilterMaxLength } from '@aws/workbench-core-base';
 import ClientSession from '../../../support/clientSession';
 import Setup from '../../../support/setup';
 import HttpError from '../../../support/utils/HttpError';
-import { checkHttpError } from '../../../support/utils/utilities';
+import { checkHttpError, generateRandomAlphaNumericString } from '../../../support/utils/utilities';
 
 describe('list environment types', () => {
   const setup: Setup = Setup.getSetup();
@@ -81,6 +82,23 @@ describe('list environment types', () => {
         new HttpError(400, {
           error: 'Bad Request',
           message: 'Cannot apply a filter and sort to different properties at the same time'
+        })
+      );
+    }
+  });
+  test('list environments types fails when filter by name exceeding length', async () => {
+    try {
+      await adminSession.resources.environmentTypes.get({
+        filter: {
+          name: { begins: generateRandomAlphaNumericString(urlFilterMaxLength + 1) }
+        }
+      });
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          error: 'Bad Request',
+          message: `filter.name.begins: ${lengthValidationMessage(urlFilterMaxLength)}`
         })
       );
     }

--- a/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/update.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environmentTypes/update.test.ts
@@ -2,10 +2,11 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
+import { swbNameMaxLength, lengthValidationMessage, swbDescriptionMaxLength } from '@aws/workbench-core-base';
 import ClientSession from '../../../support/clientSession';
 import Setup from '../../../support/setup';
 import HttpError from '../../../support/utils/HttpError';
-import { checkHttpError } from '../../../support/utils/utilities';
+import { checkHttpError, generateRandomAlphaNumericString } from '../../../support/utils/utilities';
 
 describe('update environment types', () => {
   const setup: Setup = Setup.getSetup();
@@ -46,7 +47,7 @@ describe('update environment types', () => {
     try {
       await adminSession.resources.environmentTypes.environmentType(testEnvTypeId).update(
         {
-          name: 'new Name',
+          name: 'new-Name',
           status: 'APPROVED'
         },
         true
@@ -66,16 +67,52 @@ describe('update environment types', () => {
     try {
       await adminSession.resources.environmentTypes.environmentType('wrong-format-id').update(
         {
-          name: 'new Name'
+          name: 'new_Name'
         },
         true
       );
     } catch (e) {
       checkHttpError(
         e,
-        new HttpError(404, {
-          error: 'Not Found',
-          message: `Could not find environment type wrong-format-id to update`
+        new HttpError(400, {
+          error: 'Bad Request',
+          message: 'envTypeId: Invalid ID'
+        })
+      );
+    }
+  });
+  test('fails when trying to update name surpassing length', async () => {
+    try {
+      await adminSession.resources.environmentTypes.environmentType(testEnvTypeId).update(
+        {
+          name: generateRandomAlphaNumericString(swbNameMaxLength + 1)
+        },
+        true
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          error: 'Bad Request',
+          message: `name: ${lengthValidationMessage(swbNameMaxLength)}`
+        })
+      );
+    }
+  });
+  test('fails when trying to update description surpassing length', async () => {
+    try {
+      await adminSession.resources.environmentTypes.environmentType(testEnvTypeId).update(
+        {
+          description: generateRandomAlphaNumericString(swbDescriptionMaxLength + 1)
+        },
+        true
+      );
+    } catch (e) {
+      checkHttpError(
+        e,
+        new HttpError(400, {
+          error: 'Bad Request',
+          message: `description: ${lengthValidationMessage(swbDescriptionMaxLength)}`
         })
       );
     }

--- a/solutions/swb-reference/integration-tests/tests/isolated/environments/list.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environments/list.test.ts
@@ -2,10 +2,11 @@
  *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *  SPDX-License-Identifier: Apache-2.0
  */
+import { lengthValidationMessage, urlFilterMaxLength, JSONValue } from '@aws/workbench-core-base';
 import ClientSession from '../../../support/clientSession';
 import { PaabHelper } from '../../../support/complex/paabHelper';
 import HttpError from '../../../support/utils/HttpError';
-import { checkHttpError } from '../../../support/utils/utilities';
+import { checkHttpError, generateRandomAlphaNumericString } from '../../../support/utils/utilities';
 
 describe('list environments', () => {
   const paabHelper = new PaabHelper();
@@ -26,6 +27,33 @@ describe('list environments', () => {
     'STOPPING_FAILED'
   ];
 
+  const invalidFilters = [
+    {
+      queryParams: { filter: { status: { eq: generateRandomAlphaNumericString(urlFilterMaxLength + 1) } } },
+      message: `filter.status.eq: ${lengthValidationMessage(urlFilterMaxLength)}`
+    },
+    {
+      queryParams: { filter: { name: { eq: generateRandomAlphaNumericString(urlFilterMaxLength + 1) } } },
+      message: `filter.name.eq: ${lengthValidationMessage(urlFilterMaxLength)}`
+    },
+    {
+      queryParams: {
+        filter: { createdAt: { eq: generateRandomAlphaNumericString(urlFilterMaxLength + 1) } }
+      },
+      message: `filter.createdAt.eq: ${lengthValidationMessage(urlFilterMaxLength)}`
+    },
+    {
+      queryParams: { filter: { owner: { eq: generateRandomAlphaNumericString(urlFilterMaxLength + 1) } } },
+      message: `filter.owner.eq: ${lengthValidationMessage(urlFilterMaxLength)}`
+    },
+    {
+      queryParams: {
+        filter: { projectId: { eq: generateRandomAlphaNumericString(urlFilterMaxLength + 1) } }
+      },
+      message: `filter.projectId.eq: ${lengthValidationMessage(urlFilterMaxLength)}`
+    }
+  ];
+
   beforeEach(() => {
     expect.hasAssertions();
   });
@@ -42,6 +70,25 @@ describe('list environments', () => {
   });
 
   describe('IT Admin tests', () => {
+    test.each(invalidFilters)(
+      'list environments fails with invalid filter exceeding filter length',
+      async (invalidFilter) => {
+        try {
+          await itAdminSession.resources.environments.get(
+            invalidFilter.queryParams as unknown as Record<string, JSONValue>
+          ); //undefined values are not accepted by Json value
+        } catch (e) {
+          checkHttpError(
+            e,
+            new HttpError(400, {
+              error: 'Bad Request',
+              message: invalidFilter.message
+            })
+          );
+        }
+      }
+    );
+
     test.each(validEnvStatuses)('list environments when status query is %s', async (status) => {
       const queryParams = {
         filter: { status: { eq: status } }

--- a/solutions/swb-reference/integration-tests/tests/multiStep/et-etc.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/et-etc.test.ts
@@ -78,7 +78,7 @@ describe('multiStep environment type and environment type config test', () => {
     console.log('Update Environment Type Name');
     await adminSession.resources.environmentTypes.environmentType(envType.id).update(
       {
-        name: 'updated name'
+        name: 'updated_name'
       },
       true
     );
@@ -86,7 +86,7 @@ describe('multiStep environment type and environment type config test', () => {
       .environmentType(envType.id)
       .get();
     expect(updatedNameEnvType).toMatchObject({
-      name: 'updated name'
+      name: 'updated_name'
     });
 
     //Update description for Environment Type

--- a/workbench-core/base/config/jest.config.json
+++ b/workbench-core/base/config/jest.config.json
@@ -4,7 +4,8 @@
   "coveragePathIgnorePatterns": [
     "<rootDir>/src/aws/awsService.ts",
     "<rootDir>/src/aws/clients/*",
-    "<rootDir>/src/types/relationshipDDBItem"
+    "<rootDir>/src/types/relationshipDDBItem",
+    "<rootDir>/src/services/secretsService.ts"
   ],
   "coverageThreshold": {
     "global": {

--- a/workbench-core/base/src/index.ts
+++ b/workbench-core/base/src/index.ts
@@ -50,7 +50,17 @@ import {
   provisionArtifactIdRegExpString,
   groupIDRegExpAsString,
   validRolesRegExpAsString,
-  validSshKeyUuidRegExpAsString
+  validSshKeyUuidRegExpAsString,
+  swbNameMaxLength,
+  nonEmptyMessage,
+  invalidIdMessage,
+  requiredMessage,
+  urlFilterMaxLength,
+  swbDescriptionValidChar,
+  swbNameValidChar,
+  nonHTMLValidChar,
+  swbDescriptionMaxLength,
+  lengthValidationMessage
 } from './utilities/textUtil';
 import { getPaginationParser, validateAndParse, z } from './utilities/validatorHelper';
 
@@ -103,5 +113,15 @@ export {
   runInBatches,
   validSshKeyUuidRegExpAsString,
   getPaginationParser,
-  z
+  z,
+  swbNameMaxLength,
+  nonEmptyMessage,
+  invalidIdMessage,
+  requiredMessage,
+  urlFilterMaxLength,
+  swbDescriptionValidChar,
+  swbNameValidChar,
+  nonHTMLValidChar,
+  swbDescriptionMaxLength,
+  lengthValidationMessage
 };

--- a/workbench-core/base/src/interfaces/queryStringParamFilter.ts
+++ b/workbench-core/base/src/interfaces/queryStringParamFilter.ts
@@ -3,28 +3,32 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { z } from 'zod';
+import { lengthValidationMessage, urlFilterMaxLength } from '../utilities/textUtil';
+import { z } from '../utilities/validatorHelper';
 
 /************
  *
  * Only one operator can be defined by property, if multiple operators are defined, dynamo service will throw an exception.
  *
  ************/
+const parameterFilterParser: z.ZodString = z
+  .string()
+  .max(urlFilterMaxLength, { message: lengthValidationMessage(urlFilterMaxLength) });
 // eslint-disable-next-line @rushstack/typedef-var
 export const QueryStringParamFilterParser = z
   .object({
-    eq: z.string().optional(),
-    lt: z.string().optional(),
-    lte: z.string().optional(),
-    gt: z.string().optional(),
-    gte: z.string().optional(),
+    eq: parameterFilterParser.optional(),
+    lt: parameterFilterParser.optional(),
+    lte: parameterFilterParser.optional(),
+    gt: parameterFilterParser.optional(),
+    gte: parameterFilterParser.optional(),
     between: z
       .object({
-        value1: z.string(),
-        value2: z.string()
+        value1: parameterFilterParser,
+        value2: parameterFilterParser
       })
       .optional(),
-    begins: z.string().optional()
+    begins: parameterFilterParser.optional()
   })
   .strict();
 

--- a/workbench-core/base/src/utilities/textUtil.test.ts
+++ b/workbench-core/base/src/utilities/textUtil.test.ts
@@ -6,7 +6,16 @@
 const randomUuid = '6d4e4f5b-8121-4bfb-b2c1-68b133177bbb';
 jest.mock('uuid', () => ({ v4: () => randomUuid }));
 
-import { uuidRegExp, uuidWithLowercasePrefix, uuidWithLowercasePrefixRegExp } from './textUtil';
+import {
+  etIdRegex,
+  lengthValidationMessage,
+  nonHtmlRegExp,
+  swbDescriptionRegExp,
+  swbNameRegExp,
+  uuidRegExp,
+  uuidWithLowercasePrefix,
+  uuidWithLowercasePrefixRegExp
+} from './textUtil';
 
 describe('textUtil', () => {
   describe('uuidWithLowercasePrefix', () => {
@@ -36,6 +45,53 @@ describe('textUtil', () => {
     test('invalid uuid with prefix', () => {
       const prefix = 'ABC';
       expect(`${prefix}-${randomUuid}`.match(uuidWithLowercasePrefixRegExp(prefix))).toEqual(null);
+    });
+  });
+  describe('nonHtmlRegExp', () => {
+    test('valid nonHtml', () => {
+      expect('this is a valid non html @#'.match(nonHtmlRegExp())).toEqual(
+        expect.arrayContaining([`this is a valid non html @#`])
+      );
+    });
+
+    test('invalid nonHtml', () => {
+      expect(`<script>function(){while(true)}</script>`.match(nonHtmlRegExp())).toEqual(null);
+    });
+  });
+  describe('swbNameRegExp', () => {
+    test('valid swbName', () => {
+      expect('name.name-1'.match(swbNameRegExp())).toEqual(expect.arrayContaining([`name.name-1`]));
+    });
+
+    test('invalid swbName', () => {
+      expect(`invalid name$`.match(swbNameRegExp())).toEqual(null);
+    });
+  });
+  describe('swbDescriptionRegExp', () => {
+    test('valid swbDescription', () => {
+      expect('description- desc'.match(swbDescriptionRegExp())).toEqual(
+        expect.arrayContaining([`description- desc`])
+      );
+    });
+
+    test('invalid swbDescription', () => {
+      expect(`%$<>`.match(swbDescriptionRegExp())).toEqual(null);
+    });
+  });
+  describe('etIdRegex', () => {
+    test('valid etId', () => {
+      expect('et-prod-1234567890123,pa-1234567890123'.match(etIdRegex())).toEqual(
+        expect.arrayContaining([`et-prod-1234567890123,pa-1234567890123`])
+      );
+    });
+
+    test('invalid etId', () => {
+      expect(`invalid`.match(etIdRegex())).toEqual(null);
+    });
+  });
+  describe('lengthValidationMessage', () => {
+    test('returns validation message', () => {
+      expect(lengthValidationMessage(3)).toEqual('Input must be less than 3 characters');
     });
   });
 });

--- a/workbench-core/base/src/utilities/textUtil.ts
+++ b/workbench-core/base/src/utilities/textUtil.ts
@@ -23,6 +23,11 @@ const swbDescriptionValidChar: string =
 const swbDescriptionRegExpAsString: string = '^[A-Za-z0-9-_. ]+$';
 const swbDescriptionMaxLength: number = 400;
 
+const nonEmptyMessage: string = 'Cannot be empty';
+const invalidIdMessage: string = 'Invalid ID';
+const requiredMessage: string = 'Required';
+const urlFilterMaxLength: number = 128;
+
 const groupIDRegExpAsString: string = '\\S{1,128}';
 
 const productIdRegExpString: string = 'prod-[0-9a-zA-Z]{13}';
@@ -33,6 +38,10 @@ const envTypeIdRegExpString: string = `${resourceTypeToKey.envType.toLowerCase()
 
 // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
 const uuidRegExp: RegExp = new RegExp(uuidRegExpAsString);
+
+function lengthValidationMessage(length: number): string {
+  return `Input must be less than ${length} characters`;
+}
 
 function uuidWithLowercasePrefixRegExp(prefix: string): RegExp {
   // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
@@ -82,5 +91,10 @@ export {
   validRolesRegExpAsString,
   groupIDRegExpAsString,
   validSshKeyUuidRegExpAsString,
-  etIdRegex
+  etIdRegex,
+  nonEmptyMessage,
+  invalidIdMessage,
+  requiredMessage,
+  urlFilterMaxLength,
+  lengthValidationMessage
 };

--- a/workbench-core/base/src/utilities/validatorHelper.test.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.test.ts
@@ -350,3 +350,24 @@ describe('zod.etId', () => {
     });
   });
 });
+describe('zod.nonEmpty', () => {
+  const zodParser = z.object({
+    id: z.string().nonEmpty()
+  });
+  type NonEmpType = z.infer<typeof zodParser>;
+  describe('is valid', () => {
+    const validObject = { id: 'non empty value' };
+    test('returns valid Id', () => {
+      expect(validateAndParse<NonEmpType>(zodParser, validObject)).toEqual(validObject);
+    });
+  });
+
+  describe('is not valid', () => {
+    const invalidObject = { id: '' };
+    test('returns nonEmpty message', () => {
+      expect(() => validateAndParse<NonEmpType>(zodParser, invalidObject)).toThrowError(
+        'id: Cannot be empty'
+      );
+    });
+  });
+});

--- a/workbench-core/base/src/utilities/validatorHelper.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.ts
@@ -15,7 +15,11 @@ import {
   swbDescriptionMaxLength,
   swbNameMaxLength,
   uuidWithLowercasePrefixRegExp,
-  etIdRegex
+  etIdRegex,
+  nonEmptyMessage,
+  invalidIdMessage,
+  requiredMessage,
+  lengthValidationMessage
 } from './textUtil';
 
 interface ZodPagination {
@@ -31,15 +35,16 @@ declare module 'zod' {
     swbName: () => ZodString;
     swbDescription: () => ZodString;
     etId: () => ZodString;
+    nonEmpty: () => ZodString;
   }
 }
 
 z.ZodString.prototype.required = function (): ZodString {
-  return this.min(1, { message: 'Required' });
+  return this.min(1, { message: requiredMessage });
 };
 
 z.ZodString.prototype.swbId = function (prefix: string): ZodString {
-  return this.regex(uuidWithLowercasePrefixRegExp(prefix), { message: 'Invalid ID' });
+  return this.regex(uuidWithLowercasePrefixRegExp(prefix), { message: invalidIdMessage });
 };
 
 z.ZodString.prototype.nonHTML = function (): ZodString {
@@ -48,18 +53,22 @@ z.ZodString.prototype.nonHTML = function (): ZodString {
 
 z.ZodString.prototype.swbName = function (): ZodString {
   return this.max(swbNameMaxLength, {
-    message: `Input must be less than ${swbNameMaxLength} characters`
+    message: lengthValidationMessage(swbNameMaxLength)
   }).regex(swbNameRegExp(), { message: swbNameValidChar });
 };
 
 z.ZodString.prototype.swbDescription = function (): ZodString {
   return this.max(swbDescriptionMaxLength, {
-    message: `Input must be less than ${swbDescriptionMaxLength} characters`
+    message: lengthValidationMessage(swbDescriptionMaxLength)
   }).regex(swbDescriptionRegExp(), { message: swbDescriptionValidChar });
 };
 
 z.ZodString.prototype.etId = function (): ZodString {
-  return this.regex(etIdRegex(), { message: 'Invalid ID' });
+  return this.regex(etIdRegex(), { message: invalidIdMessage });
+};
+
+z.ZodString.prototype.nonEmpty = function (): ZodString {
+  return this.min(1, { message: nonEmptyMessage });
 };
 
 function getPaginationParser(minPageSize: number = 1, maxPageSize: number = 100): ZodPagination {

--- a/workbench-core/environments/config/jest.config.json
+++ b/workbench-core/environments/config/jest.config.json
@@ -17,6 +17,7 @@
     "<rootDir>/src/models/environmentTypes/environmentType.ts",
     "<rootDir>/src/models/environmentTypes/listEnvironmentTypesRequest.ts",
     "<rootDir>/src/models/environmentTypes/updateEnvironmentTypeRequest.ts",
+    "<rootDir>/src/models/environmentTypes/getEnvironmentTypesRequest.ts",
 
     "<rootDir>/src/models/environments/environment.ts",
     "<rootDir>/src/models/environments/environmentItem.ts",

--- a/workbench-core/environments/src/index.ts
+++ b/workbench-core/environments/src/index.ts
@@ -38,6 +38,10 @@ import {
 } from './models/environmentTypeConfigs/updateEnvironmentTypeConfigsRequest';
 import { EnvironmentType } from './models/environmentTypes/environmentType';
 import {
+  GetEnvironmentTypeRequest,
+  GetEnvironmentTypeRequestParser
+} from './models/environmentTypes/getEnvironmentTypesRequest';
+import {
   ListEnvironmentTypesRequest,
   ListEnvironmentTypesRequestParser
 } from './models/environmentTypes/listEnvironmentTypesRequest';
@@ -90,5 +94,7 @@ export {
   UpdateEnvironmentTypeRequestParser,
   EnvironmentTypeConfig,
   ListEnvironmentsServiceRequestParser,
-  ListEnvironmentsServiceRequest
+  ListEnvironmentsServiceRequest,
+  GetEnvironmentTypeRequestParser,
+  GetEnvironmentTypeRequest
 };

--- a/workbench-core/environments/src/models/environmentTypes/getEnvironmentTypesRequest.ts
+++ b/workbench-core/environments/src/models/environmentTypes/getEnvironmentTypesRequest.ts
@@ -1,0 +1,15 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from '@aws/workbench-core-base';
+
+// eslint-disable-next-line @rushstack/typedef-var
+export const GetEnvironmentTypeRequestParser = z
+  .object({
+    envTypeId: z.string().etId().required()
+  })
+  .strict();
+
+export type GetEnvironmentTypeRequest = z.infer<typeof GetEnvironmentTypeRequestParser>;

--- a/workbench-core/environments/src/models/environmentTypes/listEnvironmentTypesRequest.ts
+++ b/workbench-core/environments/src/models/environmentTypes/listEnvironmentTypesRequest.ts
@@ -3,8 +3,7 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { getPaginationParser, QueryStringParamFilterParser } from '@aws/workbench-core-base';
-import { z } from 'zod';
+import { getPaginationParser, QueryStringParamFilterParser, z } from '@aws/workbench-core-base';
 
 // eslint-disable-next-line @rushstack/typedef-var
 export const ListEnvironmentTypesRequestParser = z

--- a/workbench-core/environments/src/models/environmentTypes/updateEnvironmentTypeRequest.ts
+++ b/workbench-core/environments/src/models/environmentTypes/updateEnvironmentTypeRequest.ts
@@ -3,14 +3,14 @@
  *  SPDX-License-Identifier: Apache-2.0
  */
 
-import { z } from 'zod';
+import { z } from '@aws/workbench-core-base';
 
 // eslint-disable-next-line @rushstack/typedef-var
 export const UpdateEnvironmentTypeRequestParser = z
   .object({
-    envTypeId: z.string(),
-    name: z.string().optional(),
-    description: z.string().optional(),
+    envTypeId: z.string().etId().required(),
+    name: z.string().swbName().nonEmpty().optional(),
+    description: z.string().swbDescription().optional(),
     status: z.enum(['APPROVED', 'NOT_APPROVED']).optional()
   })
   .strict();


### PR DESCRIPTION
Issue #, if available:
GALI-2321
GALI-2319
Description of changes:
Add length validation to query params
Add length and format validation to environment type routes
Add length and format validation to environment List route
Centralize validation messages
Add Zod to get ET
Add integ tests for length validation

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.