### PR TITLE
fix(swb): adding permission to allow calling Send SSH Public Key and …

### DIFF
--- a/common/changes/@aws/swb-app/kevpark-update-send-ssh-key-permission_2023-04-27-19-17.json
+++ b/common/changes/@aws/swb-app/kevpark-update-send-ssh-key-permission_2023-04-27-19-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/swb-app",
+      "comment": "Updating ssh key service send ssh public key to take in project id",
+      "type": "major"
+    }
+  ],
+  "packageName": "@aws/swb-app"
+}

--- a/solutions/swb-app/src/sshKeys/sendPublicKeyRequest.ts
+++ b/solutions/swb-app/src/sshKeys/sendPublicKeyRequest.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 // eslint-disable-next-line @rushstack/typedef-var
 export const SendPublicKeyRequestParser = z
   .object({
+    projectId: z.string(),
     environmentId: z.string(),
     userId: z.string()
   })

--- a/solutions/swb-reference/SWBv2.openapi.json
+++ b/solutions/swb-reference/SWBv2.openapi.json
@@ -2883,7 +2883,7 @@
         }
       ]
     },
-    "/environments/{environmentId}/sshKeys": {
+    "/projects/{projectId}/environments/{environmentId}/sshKeys": {
       "get": {
         "tags": ["sshKeys"],
         "summary": "Send SSH Public Key",
@@ -2912,6 +2912,15 @@
         }
       },
       "parameters": [
+        {
+          "name": "projectId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "example": ""
+          }
+        },
         {
           "name": "environmentId",
           "in": "path",

--- a/solutions/swb-reference/SWBv2.postman_collection.json
+++ b/solutions/swb-reference/SWBv2.postman_collection.json
@@ -2243,10 +2243,14 @@
               }
             ],
             "url": {
-              "raw": "{{API_URL}}/environments/:environmentId/sshKeys",
+              "raw": "{{API_URL}}/projects/:projectId/environments/:environmentId/sshKeys",
               "host": ["{{API_URL}}"],
-              "path": ["environments", ":environmentId", "sshKeys"],
+              "path": ["projects", ":projectId", "environments", ":environmentId", "sshKeys"],
               "variable": [
+                {
+                  "key": "projectId",
+                  "value": ""
+                },
                 {
                   "key": "environmentId",
                   "value": ""

--- a/solutions/swb-reference/src/dynamicRouteConfig.ts
+++ b/solutions/swb-reference/src/dynamicRouteConfig.ts
@@ -633,6 +633,18 @@ export const dynamicRoutesMap: DynamicRoutesMap = {
         }
       }
     ]
+  },
+  '/projects/:projectId/environments/:environmentId/sshKeys': {
+    GET: [
+      {
+        action: 'READ',
+        subject: {
+          subjectType: SwbAuthZSubject.SWB_SSH_KEY,
+          subjectId: '*',
+          projectId: '${projectId}'
+        }
+      }
+    ]
   }
 };
 


### PR DESCRIPTION
…requiring Project ID

This update breaks the previous implementation of Send SSH Public Key API by requiring Project ID is passed

BREAKING CHANGE: Project ID must be passed in to Send SSH Public Key API

Description of changes:
* Send SSH Public Key API now requires Project ID
* Send SSH Public Key permission added to dynamic route config

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.