### PR TITLE
fix(swb-ref): make SageMaker IAM policy case insensitive

### DIFF
--- a/solutions/swb-reference/src/SWBStack.ts
+++ b/solutions/swb-reference/src/SWBStack.ts
@@ -613,7 +613,7 @@ export class SWBStack extends Stack {
             'sagemaker:DeleteNotebookInstanceLifecycleConfig'
           ],
           resources: [
-            'arn:aws:sagemaker:*:*:notebook-instance-lifecycle-config/?asic?otebook?nstance?ifecycleConfig-*'
+            'arn:aws:sagemaker:*:*:notebook-instance-lifecycle-config/?asic?otebook?nstance?ifecycle?onfig-*'
           ]
         }),
         new PolicyStatement({

--- a/solutions/swb-reference/src/SWBStack.ts
+++ b/solutions/swb-reference/src/SWBStack.ts
@@ -613,7 +613,7 @@ export class SWBStack extends Stack {
             'sagemaker:DeleteNotebookInstanceLifecycleConfig'
           ],
           resources: [
-            'arn:aws:sagemaker:*:*:notebook-instance-lifecycle-config/BasicNotebookInstanceLifecycleConfig-*'
+            'arn:aws:sagemaker:*:*:notebook-instance-lifecycle-config/?asic?otebook?nstance?ifecycleConfig-*'
           ]
         }),
         new PolicyStatement({
@@ -625,7 +625,7 @@ export class SWBStack extends Stack {
             'sagemaker:StopNotebookInstance',
             'sagemaker:DeleteNotebookInstance'
           ],
-          resources: ['arn:aws:sagemaker:*:*:notebook-instance/BasicNotebookInstance-*']
+          resources: ['arn:aws:sagemaker:*:*:notebook-instance/?asic?otebook?nstance-*']
         }),
         new PolicyStatement({
           actions: ['s3:GetObject', 's3:GetObjectVersion'],


### PR DESCRIPTION
Description of changes:
* SageMaker resources are created with lowercase resource names due to CloudFormation. Updating IAM policies to be case insensitive with IAM Policies to account for both lower case and Pascal case.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.