### PR TITLE
fix(swb-ref): remove Access for Project in DataSetService properly ha…

### DIFF
--- a/solutions/swb-reference/src/services/dataSetService.test.ts
+++ b/solutions/swb-reference/src/services/dataSetService.test.ts
@@ -4,6 +4,7 @@
  */
 
 import {
+  ConflictError,
   CreateProvisionDatasetRequest,
   DataSet,
   DataSetExternalEndpointRequest,
@@ -512,6 +513,8 @@ describe('DataSetService', () => {
         };
 
         mockDataSetsAuthPlugin.removeAccessPermissions = jest.fn().mockReturnValueOnce(permissionsResponse);
+
+        mockWorkbenchDataSetService.getDataSet = jest.fn().mockReturnValueOnce(mockDataSet);
       });
 
       describe('when a projectAdmin removes access', () => {
@@ -527,11 +530,13 @@ describe('DataSetService', () => {
               dataSetId,
               projectId
             };
+
+            mockDataSet.owner = getProjectAdminRole(projectId);
           });
 
           test('it throws an error', async () => {
             await expect(dataSetService.removeAccessForProject(projectRemoveAccessRequest)).rejects.toThrow(
-              new Error(
+              new ConflictError(
                 `${projectId} cannot remove access from ${dataSetId} for the ProjectAdmin because it owns that dataset.`
               )
             );

--- a/solutions/swb-reference/src/services/dataSetService.ts
+++ b/solutions/swb-reference/src/services/dataSetService.ts
@@ -365,11 +365,12 @@ export class DataSetService implements DataSetPlugin {
   }
 
   public async removeAccessForProject(request: ProjectRemoveAccessRequest): Promise<PermissionsResponse> {
+    const reqDataset = await this.getDataSet(request.dataSetId, request.authenticatedUser);
     const projectAdmin = getProjectAdminRole(request.projectId);
 
     //Make sure you're not removing the access for your project
-    if (request.authenticatedUser.roles.includes(projectAdmin)) {
-      throw new Error(
+    if (projectAdmin === reqDataset.owner) {
+      throw new ConflictError(
         `${request.projectId} cannot remove access from ${request.dataSetId} for the ProjectAdmin because it owns that dataset.`
       );
     }


### PR DESCRIPTION
…ndles edge case

Description of changes:
* Remove Access for Project in DataSetService no longer errors if PA is also a PA for another Project that needs its access removed from the Dataset
* Updating error type to ConflictError so that it is returned as a 400 error rather than 500.

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.