### PR TITLE
fix: DS api and user regex fixes

### DIFF
--- a/solutions/swb-app/src/users/createUserRequest.ts
+++ b/solutions/swb-app/src/users/createUserRequest.ts
@@ -8,8 +8,8 @@ import { z, invalidEmailMessage } from '@aws/workbench-core-base';
 // eslint-disable-next-line @rushstack/typedef-var
 export const CreateUserRequestParser = z
   .object({
-    firstName: z.string().swbName().required(),
-    lastName: z.string().swbName().required(),
+    firstName: z.string().personName().required(),
+    lastName: z.string().personName().required(),
     email: z.string().email(invalidEmailMessage).required()
   })
   .strict();

--- a/solutions/swb-app/src/users/updateUserRequest.ts
+++ b/solutions/swb-app/src/users/updateUserRequest.ts
@@ -9,8 +9,8 @@ import { z, invalidEmailMessage } from '@aws/workbench-core-base';
 export const UpdateUserRequestParser = z
   .object({
     userId: z.string().required(),
-    firstName: z.string().swbName().optional(),
-    lastName: z.string().swbName().optional(),
+    firstName: z.string().personName().optional(),
+    lastName: z.string().personName().optional(),
     email: z.string().email(invalidEmailMessage).optional(),
     status: z.enum(['ACTIVE', 'INACTIVE']).optional(),
     roles: z.array(z.string().max(55)).optional()

--- a/solutions/swb-reference/src/services/dataSetService.test.ts
+++ b/solutions/swb-reference/src/services/dataSetService.test.ts
@@ -398,11 +398,18 @@ describe('DataSetService', () => {
         const permissionRequest: AddRemoveAccessPermissionRequest = {
           authenticatedUser: projectAddAccessRequest.authenticatedUser,
           dataSetId: projectAddAccessRequest.dataSetId,
-          permission: {
-            identity: 'projectId#ProjectAdmin',
-            identityType: 'GROUP',
-            accessLevel: projectAddAccessRequest.accessLevel!
-          }
+          permission: [
+            {
+              identity: 'projectId#ProjectAdmin',
+              identityType: 'GROUP',
+              accessLevel: projectAddAccessRequest.accessLevel!
+            },
+            {
+              identity: 'projectId#Researcher',
+              identityType: 'GROUP',
+              accessLevel: projectAddAccessRequest.accessLevel!
+            }
+          ]
         };
         expect(mockDataSetsAuthPlugin.addAccessPermission).toHaveBeenCalledWith(permissionRequest);
       });

--- a/solutions/swb-reference/src/services/dataSetService.ts
+++ b/solutions/swb-reference/src/services/dataSetService.ts
@@ -322,11 +322,18 @@ export class DataSetService implements DataSetPlugin {
     const permissionRequest: AddRemoveAccessPermissionRequest = {
       authenticatedUser: request.authenticatedUser,
       dataSetId: request.dataSetId,
-      permission: {
-        identity: projectAdmin,
-        identityType: 'GROUP',
-        accessLevel: request.accessLevel
-      }
+      permission: [
+        {
+          identity: projectAdmin,
+          identityType: 'GROUP',
+          accessLevel: request.accessLevel
+        },
+        {
+          identity: projectResearcher,
+          identityType: 'GROUP',
+          accessLevel: request.accessLevel
+        }
+      ]
     };
 
     const response = await this.addAccessPermission(permissionRequest);
@@ -366,6 +373,7 @@ export class DataSetService implements DataSetPlugin {
 
   public async removeAccessForProject(request: ProjectRemoveAccessRequest): Promise<PermissionsResponse> {
     const reqDataset = await this.getDataSet(request.dataSetId, request.authenticatedUser);
+    console.log(JSON.stringify(reqDataset));
     const projectAdmin = getProjectAdminRole(request.projectId);
 
     //Make sure you're not removing the access for your project

--- a/workbench-core/base/src/utilities/textUtil.test.ts
+++ b/workbench-core/base/src/utilities/textUtil.test.ts
@@ -16,6 +16,7 @@ import {
   swbDescriptionRegExp,
   awsAccountIdRegExp,
   swbNameRegExp,
+  personNameRegExp,
   uuidRegExp,
   uuidWithLowercasePrefix,
   uuidWithLowercasePrefixRegExp,
@@ -75,6 +76,22 @@ describe('textUtil', () => {
 
     test('invalid swbName', () => {
       expect(`invalid name$`.match(swbNameRegExp())).toEqual(null);
+    });
+  });
+  describe('personNameRegExp', () => {
+    test('valid personName valid char', () => {
+      expect('John Doe'.match(personNameRegExp())).toEqual(expect.arrayContaining(['John Doe']));
+      expect('John Doe 1'.match(personNameRegExp())).toEqual(expect.arrayContaining(['John Doe 1']));
+      expect('John Doe II'.match(personNameRegExp())).toEqual(expect.arrayContaining(['John Doe II']));
+      expect('Jane-Doe'.match(personNameRegExp())).toEqual(expect.arrayContaining(['Jane-Doe']));
+    });
+
+    test('invalid personName empty string', () => {
+      expect(''.match(personNameRegExp())).toEqual(null);
+    });
+
+    test('invalid personName', () => {
+      expect(`invalid name$`.match(personNameRegExp())).toEqual(null);
     });
   });
   describe('swbDescriptionRegExp', () => {

--- a/workbench-core/base/src/utilities/textUtil.ts
+++ b/workbench-core/base/src/utilities/textUtil.ts
@@ -20,6 +20,10 @@ const swbNameMessage: string = 'must contain only letters, numbers, hyphens, und
 const swbNameRegExpAsString: string = ['^[A-Za-z0-9-_.]+$', emtpyStringAsString].join('|');
 const swbNameMaxLength: number = 112;
 
+const personNameMessage: string = 'must contain only letters, spaces, numbers, and hyphens';
+const personNameRegExpAsString: string = '^[A-Za-z0-9- ]+$';
+const personNameMaxLength: number = 50;
+
 const swbDescriptionMessage: string =
   'must contain only letters, numbers, hyphens, underscores, periods, and spaces';
 const swbDescriptionRegExpAsString: string = ['^[A-Za-z0-9-_. ]+$', emtpyStringAsString].join('|');
@@ -67,6 +71,11 @@ function nonHtmlRegExp(): RegExp {
 function swbNameRegExp(): RegExp {
   // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
   return new RegExp(swbNameRegExpAsString);
+}
+
+function personNameRegExp(): RegExp {
+  // eslint-disable-next-line @rushstack/security/no-unsafe-regexp,security/detect-non-literal-regexp
+  return new RegExp(personNameRegExpAsString);
 }
 
 function swbDescriptionRegExp(): RegExp {
@@ -122,6 +131,9 @@ export {
   swbNameMessage,
   swbNameRegExp,
   swbNameMaxLength,
+  personNameMessage,
+  personNameRegExp,
+  personNameMaxLength,
   swbDescriptionMessage,
   swbDescriptionRegExp,
   swbDescriptionMaxLength,

--- a/workbench-core/base/src/utilities/validatorHelper.ts
+++ b/workbench-core/base/src/utilities/validatorHelper.ts
@@ -10,6 +10,9 @@ import {
   nonHtmlRegExp,
   swbNameMessage,
   swbNameRegExp,
+  personNameRegExp,
+  personNameMessage,
+  personNameMaxLength,
   swbDescriptionRegExp,
   swbDescriptionMessage,
   swbDescriptionMaxLength,
@@ -40,6 +43,7 @@ declare module 'zod' {
     swbId: (prefix: string) => ZodString;
     nonHTML: () => ZodString;
     swbName: () => ZodString;
+    personName: () => ZodString;
     swbDescription: () => ZodString;
     etId: () => ZodString;
     etcId: () => ZodString;
@@ -71,6 +75,12 @@ z.ZodString.prototype.swbName = function (): ZodString {
   return this.max(swbNameMaxLength, {
     message: lengthValidationMessage(swbNameMaxLength)
   }).regex(swbNameRegExp(), { message: swbNameMessage });
+};
+
+z.ZodString.prototype.personName = function (): ZodString {
+  return this.max(personNameMaxLength, {
+    message: lengthValidationMessage(personNameMaxLength)
+  }).regex(personNameRegExp(), { message: personNameMessage });
 };
 
 z.ZodString.prototype.swbDescription = function (): ZodString {


### PR DESCRIPTION
Issue #, if available:
P88136910

Description of changes:
Fix for the following finding: Dataset assigned to multiple projects and createEnvironment with that dataset returns 500

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [x] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.